### PR TITLE
Fix view mode availability highlighting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,9 @@ This version has breaking changes — APIs, conventions, and file structure may 
 
 ## Practical workflow reminders
 
+- If Codex creates a new git branch, the branch name must be English-only.
+  - use English slugs even when the user writes in German
+  - do not create German branch names like `codex/passe-viewmodemarkierung-an`
 - If changing deployment-related files, re-run at minimum:
   - `pnpm build`
   - `docker build -t tempoll-debug .`

--- a/src/components/public-event-client.test.tsx
+++ b/src/components/public-event-client.test.tsx
@@ -195,6 +195,11 @@ describe("PublicEventClient", () => {
     const cell = screen.getByRole("button", {
       name: /Mon, Mar 30 09:00 · 2\/4 available/i,
     });
+
+    expect(screen.queryByText("your availability")).not.toBeInTheDocument();
+    expect(cell).not.toHaveAttribute("data-current-user-selected");
+    expect(cell.className).not.toContain("outline-primary/85");
+
     fireEvent.click(cell);
 
     expect(screen.getByText("Slot details")).toBeInTheDocument();

--- a/src/components/public-event-client.tsx
+++ b/src/components/public-event-client.tsx
@@ -849,7 +849,7 @@ export function PublicEventClient({
                   <span className="size-3 rounded-[3px] bg-primary/65" />
                   high overlap
                 </span>
-                {session ? (
+                {session && mode === "edit" ? (
                   <span className="inline-flex items-center gap-1">
                     <span className="size-3 rounded-[3px] bg-primary/24 outline outline-2 -outline-offset-2 outline-primary/85 ring-1 ring-inset ring-background" />
                     your availability
@@ -1049,6 +1049,8 @@ export function PublicEventClient({
                           : `${date.label} ${timeRow.label} · nobody available`;
 
                         const isActiveViewSlot = mode === "view" && activeSlotKey === key;
+                        const showCurrentUserSelection =
+                          mode === "edit" && slot.selectedByCurrentUser;
                         const isHighlightedParticipantAvailable = activeParticipantId
                           ? slot.participantIds.includes(activeParticipantId)
                           : false;
@@ -1063,7 +1065,9 @@ export function PublicEventClient({
                             data-slot-key={key}
                             data-date-key={date.dateKey}
                             data-minutes={timeRow.minutes}
-                            data-current-user-selected={slot.selectedByCurrentUser ? "true" : undefined}
+                            data-current-user-selected={
+                              showCurrentUserSelection ? "true" : undefined
+                            }
                             data-highlighted-participant-availability={
                               isHighlightedParticipantAvailable ? "true" : undefined
                             }
@@ -1074,7 +1078,7 @@ export function PublicEventClient({
                                 ? "cursor-crosshair touch-none hover:brightness-[0.98]"
                                 : "cursor-pointer hover:brightness-[0.99]",
                               getHeatColor(slot.availabilityCount),
-                              getCurrentUserSelectionClass(slot.selectedByCurrentUser),
+                              getCurrentUserSelectionClass(showCurrentUserSelection),
                               getActiveViewSelectionClass(isActiveViewSlot),
                             )}
                             style={getParticipantHighlightStyle({


### PR DESCRIPTION
## Summary
- limit the current user's availability outline and legend entry to edit mode only
- keep view mode focused on the shared heatmap and selected slot details
- add a workflow note in `AGENTS.md` requiring English-only Codex branch names
- extend the public event client test to verify the current-user highlight is absent in view mode

## Testing
- `pnpm test:run src/components/public-event-client.test.tsx`
- `pnpm typecheck`