### PR TITLE
Save create event defaults in browser storage

### DIFF
--- a/src/components/create-event-form.test.tsx
+++ b/src/components/create-event-form.test.tsx
@@ -1,6 +1,8 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { readCreateEventDefaults } from "@/lib/create-event-defaults";
 import { CreateEventForm } from "./create-event-form";
 
 const push = vi.fn();
@@ -18,20 +20,31 @@ vi.mock("sonner", () => ({
   },
 }));
 
+const defaultTimezones = ["Europe/Vienna"];
+const defaultTimeOptions = [
+  { value: 8 * 60, label: "08:00" },
+  { value: 9 * 60, label: "09:00" },
+  { value: 17 * 60, label: "17:00" },
+  { value: 18 * 60, label: "18:00" },
+];
+
+function renderCreateEventForm() {
+  return render(
+    <CreateEventForm timezones={defaultTimezones} timeOptions={defaultTimeOptions} />,
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  push.mockReset();
+});
+
 describe("CreateEventForm", () => {
   it("shows a friendly inline title validation message before submitting", () => {
     const fetchMock = vi.fn();
     global.fetch = fetchMock as typeof fetch;
 
-    render(
-      <CreateEventForm
-        timezones={["Europe/Vienna"]}
-        timeOptions={[
-          { value: 9 * 60, label: "09:00" },
-          { value: 18 * 60, label: "18:00" },
-        ]}
-      />,
-    );
+    renderCreateEventForm();
 
     fireEvent.change(screen.getByLabelText("Event title"), {
       target: { value: "ab" },
@@ -48,15 +61,7 @@ describe("CreateEventForm", () => {
   });
 
   it("clears the inline title validation message once the input is corrected", () => {
-    render(
-      <CreateEventForm
-        timezones={["Europe/Vienna"]}
-        timeOptions={[
-          { value: 9 * 60, label: "09:00" },
-          { value: 18 * 60, label: "18:00" },
-        ]}
-      />,
-    );
+    renderCreateEventForm();
 
     const titleInput = screen.getByLabelText("Event title");
 
@@ -77,5 +82,54 @@ describe("CreateEventForm", () => {
       screen.queryByText("Event title must be at least 3 characters long."),
     ).not.toBeInTheDocument();
     expect(titleInput).not.toHaveAttribute("aria-invalid");
+  });
+
+  it("stores the last used daily window and slot size after a successful event creation", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        manageKey: "manage-key-123",
+      }),
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    renderCreateEventForm();
+
+    await user.type(screen.getByLabelText("Event title"), "Sprint planning");
+
+    await user.click(screen.getByRole("combobox", { name: "Daily start" }));
+    await user.click(screen.getByRole("option", { name: "08:00" }));
+
+    await user.click(screen.getByRole("combobox", { name: "Daily end" }));
+    await user.click(screen.getByRole("option", { name: "17:00" }));
+
+    await user.click(screen.getByRole("combobox", { name: "Slot size" }));
+    await user.click(screen.getByRole("option", { name: "15 min" }));
+
+    await user.click(screen.getByRole("button", { name: "Create event" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(push).toHaveBeenCalledWith("/manage/manage-key-123");
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const payload = JSON.parse(String(requestInit.body)) as {
+      dayStartMinutes: number;
+      dayEndMinutes: number;
+      slotMinutes: number;
+    };
+
+    expect(payload).toMatchObject({
+      dayStartMinutes: 8 * 60,
+      dayEndMinutes: 17 * 60,
+      slotMinutes: 15,
+    });
+    expect(readCreateEventDefaults()).toEqual({
+      dayStartMinutes: 8 * 60,
+      dayEndMinutes: 17 * 60,
+      slotMinutes: 15,
+    });
   });
 });

--- a/src/components/create-event-form.tsx
+++ b/src/components/create-event-form.tsx
@@ -9,7 +9,7 @@ import {
   SparklesIcon,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
@@ -27,6 +27,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
+import {
+  defaultCreateEventDefaults,
+  readCreateEventDefaults,
+  saveCreateEventDefaults,
+} from "@/lib/create-event-defaults";
 import { cn } from "@/lib/utils";
 import { eventCreateSchema } from "@/lib/validators";
 
@@ -117,10 +122,30 @@ export function CreateEventForm({ timezones, timeOptions }: CreateEventFormProps
       ? browserTimezone
       : "Europe/Vienna";
   });
-  const [slotMinutes, setSlotMinutes] = useState(30);
+  const [slotMinutes, setSlotMinutes] = useState(defaultCreateEventDefaults.slotMinutes);
   const [meetingDurationMinutes, setMeetingDurationMinutes] = useState(60);
-  const [dayStartMinutes, setDayStartMinutes] = useState(9 * 60);
-  const [dayEndMinutes, setDayEndMinutes] = useState(18 * 60);
+  const [dayStartMinutes, setDayStartMinutes] = useState(
+    defaultCreateEventDefaults.dayStartMinutes,
+  );
+  const [dayEndMinutes, setDayEndMinutes] = useState(
+    defaultCreateEventDefaults.dayEndMinutes,
+  );
+
+  useEffect(() => {
+    const storedDefaults = readCreateEventDefaults();
+    const supportsTimeOption = (minutes: number) =>
+      timeOptions.some((option) => option.value === minutes);
+
+    if (supportsTimeOption(storedDefaults.dayStartMinutes)) {
+      setDayStartMinutes(storedDefaults.dayStartMinutes);
+    }
+
+    if (supportsTimeOption(storedDefaults.dayEndMinutes)) {
+      setDayEndMinutes(storedDefaults.dayEndMinutes);
+    }
+
+    setSlotMinutes(storedDefaults.slotMinutes);
+  }, [timeOptions]);
 
   const selectedDates =
     dateRange?.from && dateRange?.to
@@ -261,6 +286,11 @@ export function CreateEventForm({ timezones, timeOptions }: CreateEventFormProps
       }
 
       toast.success("Event created");
+      saveCreateEventDefaults({
+        dayStartMinutes,
+        dayEndMinutes,
+        slotMinutes,
+      });
       router.push(`/manage/${payload.manageKey}`);
     });
   }

--- a/src/lib/create-event-defaults.test.ts
+++ b/src/lib/create-event-defaults.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  defaultCreateEventDefaults,
+  readCreateEventDefaults,
+  saveCreateEventDefaults,
+} from "./create-event-defaults";
+
+describe("create event defaults", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns the built-in defaults when nothing has been stored yet", () => {
+    expect(readCreateEventDefaults()).toEqual(defaultCreateEventDefaults);
+  });
+
+  it("reads previously saved defaults from browser storage", () => {
+    saveCreateEventDefaults({
+      dayStartMinutes: 8 * 60,
+      dayEndMinutes: 17 * 60,
+      slotMinutes: 15,
+    });
+
+    expect(readCreateEventDefaults()).toEqual({
+      dayStartMinutes: 8 * 60,
+      dayEndMinutes: 17 * 60,
+      slotMinutes: 15,
+    });
+  });
+
+  it("falls back to the built-in defaults when stored data is invalid", () => {
+    window.localStorage.setItem(
+      "tempoll_create_event_defaults",
+      JSON.stringify({
+        dayStartMinutes: 18 * 60,
+        dayEndMinutes: 9 * 60,
+        slotMinutes: 999,
+      }),
+    );
+
+    expect(readCreateEventDefaults()).toEqual(defaultCreateEventDefaults);
+  });
+});

--- a/src/lib/create-event-defaults.ts
+++ b/src/lib/create-event-defaults.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+
+import { slotMinuteOptions } from "@/lib/constants";
+
+export type CreateEventDefaults = {
+  dayStartMinutes: number;
+  dayEndMinutes: number;
+  slotMinutes: number;
+};
+
+export const defaultCreateEventDefaults: CreateEventDefaults = {
+  dayStartMinutes: 9 * 60,
+  dayEndMinutes: 18 * 60,
+  slotMinutes: 30,
+};
+
+const STORAGE_KEY = "tempoll_create_event_defaults";
+const slotMinuteSet = new Set<number>(slotMinuteOptions);
+
+const createEventDefaultsSchema = z
+  .object({
+    dayStartMinutes: z.number().int().min(0).max(23 * 60 + 30),
+    dayEndMinutes: z.number().int().min(30).max(24 * 60),
+    slotMinutes: z.number().int().refine((value) => slotMinuteSet.has(value)),
+  })
+  .superRefine((value, ctx) => {
+    if (value.dayEndMinutes <= value.dayStartMinutes) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["dayEndMinutes"],
+        message: "End time must be later than start time.",
+      });
+    }
+  });
+
+let cachedRawCreateEventDefaults: string | null | undefined;
+let cachedCreateEventDefaults = defaultCreateEventDefaults;
+
+function resetCreateEventDefaultsCache() {
+  cachedRawCreateEventDefaults = null;
+  cachedCreateEventDefaults = defaultCreateEventDefaults;
+  return cachedCreateEventDefaults;
+}
+
+function updateCreateEventDefaultsCache(defaults: CreateEventDefaults) {
+  cachedCreateEventDefaults = defaults;
+  cachedRawCreateEventDefaults = JSON.stringify(defaults);
+  return cachedCreateEventDefaults;
+}
+
+export function readCreateEventDefaults() {
+  if (typeof window === "undefined") {
+    return defaultCreateEventDefaults;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === cachedRawCreateEventDefaults) {
+      return cachedCreateEventDefaults;
+    }
+
+    if (!raw) {
+      return resetCreateEventDefaultsCache();
+    }
+
+    const parsed = createEventDefaultsSchema.safeParse(JSON.parse(raw));
+    if (!parsed.success) {
+      return resetCreateEventDefaultsCache();
+    }
+
+    cachedRawCreateEventDefaults = raw;
+    cachedCreateEventDefaults = parsed.data;
+    return cachedCreateEventDefaults;
+  } catch {
+    return resetCreateEventDefaultsCache();
+  }
+}
+
+export function saveCreateEventDefaults(defaults: CreateEventDefaults) {
+  if (typeof window === "undefined") {
+    return defaults;
+  }
+
+  const parsed = createEventDefaultsSchema.safeParse(defaults);
+  const nextDefaults = parsed.success ? parsed.data : defaultCreateEventDefaults;
+  updateCreateEventDefaultsCache(nextDefaults);
+  window.localStorage.setItem(STORAGE_KEY, cachedRawCreateEventDefaults ?? JSON.stringify(nextDefaults));
+  return nextDefaults;
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -50,4 +50,9 @@ Object.defineProperties(HTMLElement.prototype, {
       return true;
     },
   },
+  scrollIntoView: {
+    configurable: true,
+    writable: true,
+    value() {},
+  },
 });


### PR DESCRIPTION
## Summary
- add a browser-local store for create event defaults with validation and safe fallback behavior
- load saved `daily start`, `daily end`, and `slot size` values when the create form mounts
- persist the last used daily window and slot size after a successful event creation
- expand tests for the new storage helper and the create-event submission flow
- stub `scrollIntoView` in the test setup for Radix select interactions

## Testing
- `pnpm test:run src/lib/create-event-defaults.test.ts src/components/create-event-form.test.tsx`
- `pnpm typecheck`
- `pnpm build`