### PR TITLE
Fix CI failures in app chrome linting and production audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "react": "19.2.4",
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.4",
-    "shadcn": "^4.1.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
@@ -61,6 +60,7 @@
     "jsdom": "^29.0.1",
     "playwright": "^1.58.2",
     "prisma": "^7.5.0",
+    "shadcn": "^4.1.0",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
-      shadcn:
-        specifier: ^4.1.0
-        version: 4.1.0(@types/node@20.19.37)(typescript@5.9.3)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -132,6 +129,9 @@ importers:
       prisma:
         specifier: ^7.5.0
         version: 7.5.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      shadcn:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@20.19.37)(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.2.2

--- a/src/components/app-chrome.test.tsx
+++ b/src/components/app-chrome.test.tsx
@@ -50,4 +50,32 @@ describe("AppChrome", () => {
     expect(screen.queryByAltText("tempoll")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "tempoll" })).toHaveTextContent("tempoll");
   });
+
+  it("shows a new logo again after a previous logo failed", () => {
+    const { rerender } = render(
+      <AppChrome
+        appName="tempoll"
+        logoSrc="/tempoll-logo.png"
+        setupComplete
+        legalPagesEnabled={false}
+      >
+        <div>content</div>
+      </AppChrome>,
+    );
+
+    fireEvent.error(screen.getByAltText("tempoll"));
+
+    rerender(
+      <AppChrome
+        appName="tempoll"
+        logoSrc="/tempoll-logo-2.png"
+        setupComplete
+        legalPagesEnabled={false}
+      >
+        <div>content</div>
+      </AppChrome>,
+    );
+
+    expect(screen.getByAltText("tempoll")).toHaveAttribute("src", "/tempoll-logo-2.png");
+  });
 });

--- a/src/components/app-chrome.tsx
+++ b/src/components/app-chrome.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -27,13 +27,9 @@ export function AppChrome({
 }: AppChromeProps) {
   const pathname = usePathname();
   const hideChrome = !setupComplete && pathname === "/setup";
-  const [logoFailed, setLogoFailed] = useState(false);
+  const [failedLogoSrc, setFailedLogoSrc] = useState<string | null>(null);
 
-  useEffect(() => {
-    setLogoFailed(false);
-  }, [logoSrc]);
-
-  const showLogo = Boolean(logoSrc) && !logoFailed;
+  const showLogo = Boolean(logoSrc) && failedLogoSrc !== logoSrc;
 
   if (hideChrome) {
     return <>{children}</>;
@@ -52,7 +48,7 @@ export function AppChrome({
                 src={logoSrc}
                 alt={appName}
                 className="h-7 w-auto shrink-0"
-                onError={() => setLogoFailed(true)}
+                onError={() => setFailedLogoSrc(logoSrc)}
               />
             ) : (
               appName


### PR DESCRIPTION
## Summary
- replace the effect-based logo failure reset with source-aware state tracking in `AppChrome`
- add a regression test covering a failed logo followed by a new logo source
- move `shadcn` from production dependencies to dev dependencies so `pnpm audit --prod` no longer fails on a CLI-only transitive vulnerability
- update `pnpm-lock.yaml` to match the dependency move

## Testing
- `pnpm lint`
- `pnpm audit --prod`
- `pnpm test:run`
- `pnpm typecheck`
- `pnpm prisma:generate`
- `pnpm build`
- `docker build -t tempoll-debug .`