### PR TITLE
Add fixed event dates with organizer heatmap selection and ICS export

### DIFF
--- a/prisma/migrations/20260328153000_add_final_slot_start_at/migration.sql
+++ b/prisma/migrations/20260328153000_add_final_slot_start_at/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "Event"
+ADD COLUMN "finalSlotStartAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model Event {
   dayStartMinutes        Int
   dayEndMinutes          Int
   status                 EventStatus        @default(OPEN)
+  finalSlotStartAt       DateTime?
   manageTokenHash        String
   createdAt              DateTime           @default(now())
   updatedAt              DateTime           @updatedAt

--- a/src/app/api/events/[slug]/ics/route.test.ts
+++ b/src/app/api/events/[slug]/ics/route.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getPublicEventSnapshot = vi.fn();
+
+vi.mock("@/lib/event-service", () => ({
+  getPublicEventSnapshot,
+}));
+
+describe("GET /api/events/[slug]/ics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a calendar file for closed events with a fixed date", async () => {
+    getPublicEventSnapshot.mockResolvedValue({
+      snapshot: {
+        slug: "team-sync",
+        title: "Team Sync",
+        timezone: "Europe/Vienna",
+        status: "CLOSED",
+        finalizedSlot: {
+          slotStart: "2026-04-02T07:00:00.000Z",
+          slotEnd: "2026-04-02T08:00:00.000Z",
+          dateKey: "2026-04-02",
+          label: "Thu, Apr 2 · 09:00-10:00",
+          localLabel: null,
+          availableCount: 2,
+          participantIds: ["p1", "p2"],
+        },
+      },
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(new Request("https://tempoll.example.com/api/events/team-sync/ics"), {
+      params: Promise.resolve({
+        slug: "team-sync",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/calendar");
+    expect(response.headers.get("content-disposition")).toContain("tempoll-team-sync.ics");
+
+    const body = await response.text();
+    expect(body).toContain("BEGIN:VCALENDAR");
+    expect(body).toContain("SUMMARY:Team Sync");
+    expect(body).toContain("DTSTART;TZID=Europe/Vienna:20260402T090000");
+    expect(body).toContain("URL:http://localhost:3000/e/team-sync");
+  });
+
+  it("returns 404 when no fixed date exists", async () => {
+    getPublicEventSnapshot.mockResolvedValue({
+      snapshot: {
+        slug: "team-sync",
+        title: "Team Sync",
+        timezone: "Europe/Vienna",
+        status: "OPEN",
+        finalizedSlot: null,
+      },
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(new Request("https://tempoll.example.com/api/events/team-sync/ics"), {
+      params: Promise.resolve({
+        slug: "team-sync",
+      }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Event not found.",
+    });
+  });
+});

--- a/src/app/api/events/[slug]/ics/route.ts
+++ b/src/app/api/events/[slug]/ics/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+
+import { getPublicEventSnapshot } from "@/lib/event-service";
+import { buildEventCalendarFile } from "@/lib/ics";
+import { PUBLIC_NO_STORE_HEADERS, mergeHeaders } from "@/lib/security";
+import { buildPublicEventUrl } from "@/lib/tokens";
+
+type Context = {
+  params: Promise<{
+    slug: string;
+  }>;
+};
+
+export const dynamic = "force-dynamic";
+
+export async function GET(_request: Request, { params }: Context) {
+  const { slug } = await params;
+  const event = await getPublicEventSnapshot(slug);
+
+  if (!event || event.snapshot.status !== "CLOSED" || !event.snapshot.finalizedSlot) {
+    return NextResponse.json(
+      { error: "Event not found." },
+      {
+        status: 404,
+        headers: mergeHeaders(PUBLIC_NO_STORE_HEADERS),
+      },
+    );
+  }
+
+  const body = buildEventCalendarFile({
+    slug: event.snapshot.slug,
+    title: event.snapshot.title,
+    timezone: event.snapshot.timezone,
+    slotStart: event.snapshot.finalizedSlot.slotStart,
+    slotEnd: event.snapshot.finalizedSlot.slotEnd,
+    url: buildPublicEventUrl(event.snapshot.slug),
+  });
+
+  return new NextResponse(body, {
+    status: 200,
+    headers: mergeHeaders(PUBLIC_NO_STORE_HEADERS, {
+      "Content-Disposition": `attachment; filename="tempoll-${event.snapshot.slug}.ics"`,
+      "Content-Type": "text/calendar; charset=utf-8",
+    }),
+  });
+}

--- a/src/app/api/manage/[token]/route.test.ts
+++ b/src/app/api/manage/[token]/route.test.ts
@@ -35,6 +35,7 @@ describe("PATCH /api/manage/[token]", () => {
           action: "updateEvent",
           title: "Updated title",
           status: "OPEN",
+          finalSlotStart: null,
         }),
         headers: {
           "Content-Type": "application/json",
@@ -65,6 +66,7 @@ describe("PATCH /api/manage/[token]", () => {
           action: "updateEvent",
           title: "Updated title",
           status: "OPEN",
+          finalSlotStart: null,
         }),
         headers: {
           "Content-Type": "application/json",

--- a/src/components/event-heatmap.tsx
+++ b/src/components/event-heatmap.tsx
@@ -1,0 +1,1120 @@
+"use client";
+
+import {
+  CalendarDaysIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  Clock3Icon,
+  LockIcon,
+  UsersIcon,
+} from "lucide-react";
+import {
+  Fragment,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { buildFinalizedSlot, getAllowedFinalSlotStarts } from "@/lib/availability";
+import type { PublicEventSnapshot, SnapshotParticipant, SnapshotSlot } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+
+export type DraftSelection = Record<string, boolean>;
+export type BoardMode = "edit" | "view";
+
+type PaintSession = {
+  pointerId: number;
+  value: boolean;
+  paintedKeys: Set<string>;
+};
+
+type DescriptionOptions = {
+  mode: BoardMode;
+  usesDateWindowing: boolean;
+};
+
+type EventHeatmapProps = {
+  snapshot: PublicEventSnapshot;
+  mode: BoardMode;
+  onModeChange?: (mode: BoardMode) => void;
+  canEdit: boolean;
+  selectedMap?: DraftSelection;
+  onUpdateCell?: (dateKey: string, minutes: number, nextValue?: boolean) => boolean;
+  displayStatus?: PublicEventSnapshot["status"];
+  finalSlotStart: string | null;
+  allowFinalSlotSelection?: boolean;
+  onFinalSlotSelect?: (slotStart: string) => void;
+  sessionBadgeLabel?: string | null;
+  showModeToggle?: boolean;
+  sidebarTopContent?: ReactNode;
+  getDescription?: (options: DescriptionOptions) => string;
+};
+
+const GRID_TIME_COLUMN_WIDTH_PX = 72;
+const GRID_DAY_COLUMN_MIN_WIDTH_PX = 84;
+
+function slotKey(dateKey: string, minutes: number) {
+  return `${dateKey}-${minutes}`;
+}
+
+function getHeatColor(availabilityCount: number) {
+  if (availabilityCount >= 6) {
+    return "bg-primary/80";
+  }
+
+  if (availabilityCount === 5) {
+    return "bg-primary/65";
+  }
+
+  if (availabilityCount === 4) {
+    return "bg-primary/50";
+  }
+
+  if (availabilityCount === 3) {
+    return "bg-primary/36";
+  }
+
+  if (availabilityCount === 2) {
+    return "bg-primary/24";
+  }
+
+  if (availabilityCount === 1) {
+    return "bg-primary/12";
+  }
+
+  return "bg-background";
+}
+
+function getCurrentUserSelectionClass(isSelected: boolean) {
+  if (!isSelected) {
+    return "";
+  }
+
+  return "outline outline-2 -outline-offset-2 outline-primary/85 ring-2 ring-inset ring-background";
+}
+
+function getActiveViewSelectionClass(isActive: boolean) {
+  if (!isActive) {
+    return "";
+  }
+
+  return "ring-2 ring-inset ring-foreground/20";
+}
+
+function getFinalizedSlotClass(options: { isInFinalSlotWindow: boolean; isFinalSlotStart: boolean }) {
+  if (!options.isInFinalSlotWindow) {
+    return "";
+  }
+
+  return options.isFinalSlotStart
+    ? "shadow-[inset_0_0_0_9999px_rgba(245,158,11,0.38)] ring-2 ring-inset ring-amber-600"
+    : "shadow-[inset_0_0_0_9999px_rgba(245,158,11,0.18)] ring-1 ring-inset ring-amber-500/70";
+}
+
+function getParticipantHighlightStyle({
+  isHighlighted,
+  participantColor,
+}: {
+  isHighlighted: boolean;
+  participantColor?: string;
+}): CSSProperties | undefined {
+  if (!isHighlighted || !participantColor) {
+    return undefined;
+  }
+
+  return {
+    backgroundImage: `linear-gradient(135deg, transparent 0%, transparent 56%, ${participantColor}99 56%, ${participantColor}99 69%, transparent 69%, transparent 100%)`,
+  };
+}
+
+function getCellHeightClass(slotMinutes: number) {
+  if (slotMinutes <= 15) {
+    return "h-4";
+  }
+
+  if (slotMinutes <= 30) {
+    return "h-5";
+  }
+
+  return "h-7";
+}
+
+function splitDateLabel(label: string) {
+  const [weekday, monthDay] = label.split(", ");
+
+  return {
+    weekday: weekday ?? label,
+    monthDay: monthDay ?? "",
+  };
+}
+
+function isMajorTimeLabel(minutes: number) {
+  return minutes % 60 === 0;
+}
+
+function getSelectedMap(snapshot: PublicEventSnapshot) {
+  return snapshot.slots.reduce<DraftSelection>((acc, slot) => {
+    acc[slotKey(slot.dateKey, slot.minutes)] = slot.selectedByCurrentUser;
+    return acc;
+  }, {});
+}
+
+function getVisibleDayCount(containerWidth: number, totalDays: number) {
+  if (totalDays === 0) {
+    return 0;
+  }
+
+  if (containerWidth <= 0) {
+    return totalDays;
+  }
+
+  const fullGridWidth = GRID_TIME_COLUMN_WIDTH_PX + totalDays * GRID_DAY_COLUMN_MIN_WIDTH_PX;
+  if (containerWidth >= fullGridWidth) {
+    return totalDays;
+  }
+
+  const availableWidth = Math.max(
+    containerWidth - GRID_TIME_COLUMN_WIDTH_PX,
+    GRID_DAY_COLUMN_MIN_WIDTH_PX,
+  );
+
+  return Math.max(1, Math.floor(availableWidth / GRID_DAY_COLUMN_MIN_WIDTH_PX));
+}
+
+function clampVisibleDateStartIndex(startIndex: number, totalDays: number, visibleDayCount: number) {
+  const maxStartIndex = Math.max(totalDays - visibleDayCount, 0);
+  return Math.min(Math.max(startIndex, 0), maxStartIndex);
+}
+
+function getVisibleRangeLabel(dates: PublicEventSnapshot["dates"]) {
+  if (!dates.length) {
+    return "";
+  }
+
+  if (dates.length === 1) {
+    return dates[0].label;
+  }
+
+  return `${dates[0].label} to ${dates[dates.length - 1].label}`;
+}
+
+function getSlotElementFromPoint(clientX: number, clientY: number) {
+  const elements =
+    typeof document.elementsFromPoint === "function"
+      ? document.elementsFromPoint(clientX, clientY)
+      : [document.elementFromPoint(clientX, clientY)].filter(Boolean);
+
+  for (const element of elements) {
+    if (!(element instanceof HTMLElement)) {
+      continue;
+    }
+
+    const slotElement = element.closest<HTMLElement>("[data-slot-key]");
+    if (slotElement instanceof HTMLButtonElement) {
+      return slotElement;
+    }
+  }
+
+  return null;
+}
+
+function getSlotCoordinatesFromElement(element: HTMLElement) {
+  const dateKey = element.dataset.dateKey;
+  const minutes = Number(element.dataset.minutes);
+  if (!dateKey || Number.isNaN(minutes)) {
+    return null;
+  }
+
+  return {
+    dateKey,
+    minutes,
+    key: element.dataset.slotKey ?? slotKey(dateKey, minutes),
+  };
+}
+
+function getDefaultDescription({ mode, usesDateWindowing }: DescriptionOptions) {
+  if (mode === "edit") {
+    return usesDateWindowing
+      ? "Tap or drag to paint your availability. Use the arrows to move day by day."
+      : "Click or drag across the grid to paint your availability while keeping the team heatmap in view.";
+  }
+
+  return usesDateWindowing
+    ? "Select a slot to inspect availability. Use the arrows to move through the date range."
+    : "Click any slot to see who is available and who is not.";
+}
+
+export function EventHeatmap({
+  snapshot,
+  mode,
+  onModeChange,
+  canEdit,
+  selectedMap,
+  onUpdateCell,
+  displayStatus = snapshot.status,
+  finalSlotStart,
+  allowFinalSlotSelection = false,
+  onFinalSlotSelect,
+  sessionBadgeLabel = null,
+  showModeToggle = true,
+  sidebarTopContent,
+  getDescription,
+}: EventHeatmapProps) {
+  const [activeSlotKey, setActiveSlotKey] = useState<string | null>(null);
+  const [activeParticipantId, setActiveParticipantId] = useState<string | null>(null);
+  const [gridContainerWidth, setGridContainerWidth] = useState(0);
+  const [visibleDateStartIndex, setVisibleDateStartIndex] = useState(0);
+  const gridContainerRef = useRef<HTMLDivElement | null>(null);
+  const paintSessionRef = useRef<PaintSession | null>(null);
+  const effectiveSelectedMap = selectedMap ?? getSelectedMap(snapshot);
+  const supportsPainting = canEdit && Boolean(onUpdateCell);
+  const currentParticipantId = snapshot.currentParticipant?.id ?? null;
+  const cellHeightClass = getCellHeightClass(snapshot.slotMinutes);
+  const slotStartSelections = useMemo(
+    () =>
+      getAllowedFinalSlotStarts({
+        dates: snapshot.dates.map((date) => date.dateKey),
+        timezone: snapshot.timezone,
+        dayStartMinutes: snapshot.dayStartMinutes,
+        dayEndMinutes: snapshot.dayEndMinutes,
+        slotMinutes: snapshot.slotMinutes,
+        meetingDurationMinutes: snapshot.meetingDurationMinutes,
+      }),
+    [
+      snapshot.dates,
+      snapshot.dayEndMinutes,
+      snapshot.dayStartMinutes,
+      snapshot.meetingDurationMinutes,
+      snapshot.slotMinutes,
+      snapshot.timezone,
+    ],
+  );
+
+  useEffect(() => {
+    if (mode === "edit") {
+      setActiveSlotKey(null);
+    }
+  }, [mode]);
+
+  const measureGridContainer = useCallback(() => {
+    const nextWidth = gridContainerRef.current?.clientWidth || window.innerWidth;
+    setGridContainerWidth((current) => (current === nextWidth ? current : nextWidth));
+  }, []);
+
+  useEffect(() => {
+    measureGridContainer();
+
+    const handleResize = () => {
+      measureGridContainer();
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    if (!gridContainerRef.current || typeof ResizeObserver === "undefined") {
+      return () => window.removeEventListener("resize", handleResize);
+    }
+
+    const observer = new ResizeObserver(() => {
+      measureGridContainer();
+    });
+    observer.observe(gridContainerRef.current);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      observer.disconnect();
+    };
+  }, [measureGridContainer]);
+
+  useEffect(() => {
+    if (!activeParticipantId) {
+      return;
+    }
+
+    const participantExists = snapshot.participants.some(
+      (participant) => participant.id === activeParticipantId,
+    );
+    if (!participantExists) {
+      setActiveParticipantId(null);
+    }
+  }, [activeParticipantId, snapshot.participants]);
+
+  const slotMap = useMemo(
+    () =>
+      new Map(
+        snapshot.slots.map((slot) => {
+          const key = slotKey(slot.dateKey, slot.minutes);
+          const selectedByCurrentUser = effectiveSelectedMap[key] ?? false;
+          let participantIds = slot.participantIds;
+
+          if (currentParticipantId) {
+            if (selectedByCurrentUser && !slot.selectedByCurrentUser) {
+              participantIds = slot.participantIds.includes(currentParticipantId)
+                ? slot.participantIds
+                : [...slot.participantIds, currentParticipantId];
+            } else if (!selectedByCurrentUser && slot.selectedByCurrentUser) {
+              participantIds = slot.participantIds.filter(
+                (participantId) => participantId !== currentParticipantId,
+              );
+            }
+          }
+
+          return [
+            key,
+            {
+              ...slot,
+              participantIds,
+              availabilityCount: participantIds.length,
+              selectedByCurrentUser,
+            },
+          ];
+        }),
+      ),
+    [currentParticipantId, effectiveSelectedMap, snapshot.slots],
+  );
+  const dateLabelsByKey = useMemo(
+    () => new Map(snapshot.dates.map((date) => [date.dateKey, date.label])),
+    [snapshot.dates],
+  );
+  const timeLabelsByMinutes = useMemo(
+    () => new Map(snapshot.timeRows.map((timeRow) => [timeRow.minutes, timeRow.label])),
+    [snapshot.timeRows],
+  );
+  const participantNamesById = useMemo(
+    () => new Map(snapshot.participants.map((participant) => [participant.id, participant.displayName])),
+    [snapshot.participants],
+  );
+  const participantColorById = useMemo(
+    () => new Map(snapshot.participants.map((participant) => [participant.id, participant.color])),
+    [snapshot.participants],
+  );
+  const participantsWithAvailability = useMemo(
+    () => snapshot.participants.filter((participant) => participant.selectedSlotCount > 0),
+    [snapshot.participants],
+  );
+  const visibleDayCount = useMemo(
+    () => getVisibleDayCount(gridContainerWidth, snapshot.dates.length),
+    [gridContainerWidth, snapshot.dates.length],
+  );
+  const usesDateWindowing = visibleDayCount > 0 && visibleDayCount < snapshot.dates.length;
+  const clampedVisibleDateStartIndex = useMemo(
+    () =>
+      clampVisibleDateStartIndex(visibleDateStartIndex, snapshot.dates.length, visibleDayCount || 1),
+    [visibleDateStartIndex, snapshot.dates.length, visibleDayCount],
+  );
+  const visibleDates = useMemo(() => {
+    if (!usesDateWindowing) {
+      return snapshot.dates;
+    }
+
+    return snapshot.dates.slice(
+      clampedVisibleDateStartIndex,
+      clampedVisibleDateStartIndex + visibleDayCount,
+    );
+  }, [clampedVisibleDateStartIndex, snapshot.dates, usesDateWindowing, visibleDayCount]);
+  const visibleDateKeys = useMemo(() => new Set(visibleDates.map((date) => date.dateKey)), [visibleDates]);
+  const canShowPreviousDates = usesDateWindowing && clampedVisibleDateStartIndex > 0;
+  const canShowNextDates =
+    usesDateWindowing &&
+    clampedVisibleDateStartIndex + visibleDates.length < snapshot.dates.length;
+  const visibleRangeLabel = useMemo(() => getVisibleRangeLabel(visibleDates), [visibleDates]);
+  const activeParticipant =
+    activeParticipantId
+      ? snapshot.participants.find((participant) => participant.id === activeParticipantId) ?? null
+      : null;
+  const activeSlot = activeSlotKey ? (slotMap.get(activeSlotKey) ?? null) : null;
+  const activeSlotDetails = useMemo(() => {
+    if (!activeSlot) {
+      return null;
+    }
+
+    const availableSet = new Set(activeSlot.participantIds);
+
+    return {
+      slot: activeSlot,
+      dateLabel: dateLabelsByKey.get(activeSlot.dateKey) ?? activeSlot.dateKey,
+      timeLabel: timeLabelsByMinutes.get(activeSlot.minutes) ?? "",
+      availableParticipants: snapshot.participants.filter((participant) =>
+        availableSet.has(participant.id),
+      ),
+      unavailableParticipants: participantsWithAvailability.filter(
+        (participant) => !availableSet.has(participant.id),
+      ),
+      isValidFinalSlotStart: slotStartSelections.has(activeSlot.slotStart),
+      isFinalSlotStart: finalSlotStart === activeSlot.slotStart,
+    };
+  }, [
+    activeSlot,
+    dateLabelsByKey,
+    finalSlotStart,
+    participantsWithAvailability,
+    slotStartSelections,
+    snapshot.participants,
+    timeLabelsByMinutes,
+  ]);
+
+  const finalizedSlot = useMemo(() => {
+    if (!finalSlotStart) {
+      return null;
+    }
+
+    return buildFinalizedSlot({
+      dates: snapshot.dates.map((date) => date.dateKey),
+      timezone: snapshot.timezone,
+      dayStartMinutes: snapshot.dayStartMinutes,
+      dayEndMinutes: snapshot.dayEndMinutes,
+      slotMinutes: snapshot.slotMinutes,
+      meetingDurationMinutes: snapshot.meetingDurationMinutes,
+      slots: Array.from(slotMap.values()),
+      finalSlotStart,
+    });
+  }, [
+    finalSlotStart,
+    slotMap,
+    snapshot.dates,
+    snapshot.dayEndMinutes,
+    snapshot.dayStartMinutes,
+    snapshot.meetingDurationMinutes,
+    snapshot.slotMinutes,
+    snapshot.timezone,
+  ]);
+  const finalizedSlotKeys = useMemo(() => {
+    if (!finalizedSlot) {
+      return new Set<string>();
+    }
+
+    const rangeStart = new Date(finalizedSlot.slotStart).getTime();
+    const rangeEnd = new Date(finalizedSlot.slotEnd).getTime();
+
+    return new Set(
+      Array.from(slotMap.entries())
+        .filter(([, slot]) => {
+          const slotTime = new Date(slot.slotStart).getTime();
+          return slotTime >= rangeStart && slotTime < rangeEnd;
+        })
+        .map(([key]) => key),
+    );
+  }, [finalizedSlot, slotMap]);
+
+  useEffect(() => {
+    setVisibleDateStartIndex((current) =>
+      clampVisibleDateStartIndex(current, snapshot.dates.length, visibleDayCount || 1),
+    );
+  }, [snapshot.dates.length, visibleDayCount]);
+
+  useEffect(() => {
+    if (!activeSlotKey || mode !== "view") {
+      return;
+    }
+
+    const slot = slotMap.get(activeSlotKey);
+    if (!slot || !visibleDateKeys.has(slot.dateKey)) {
+      setActiveSlotKey(null);
+    }
+  }, [activeSlotKey, mode, slotMap, visibleDateKeys]);
+
+  const moveVisibleDateWindow = useCallback(
+    (direction: -1 | 1) => {
+      setVisibleDateStartIndex((current) =>
+        clampVisibleDateStartIndex(current + direction, snapshot.dates.length, visibleDayCount || 1),
+      );
+    },
+    [snapshot.dates.length, visibleDayCount],
+  );
+
+  const paintCellInSession = useCallback(
+    (session: PaintSession, dateKey: string, minutes: number) => {
+      if (!onUpdateCell) {
+        return;
+      }
+
+      const key = slotKey(dateKey, minutes);
+      if (session.paintedKeys.has(key)) {
+        return;
+      }
+
+      session.paintedKeys.add(key);
+      onUpdateCell(dateKey, minutes, session.value);
+    },
+    [onUpdateCell],
+  );
+
+  const continuePaintSession = useCallback(
+    (clientX: number, clientY: number, fallbackDateKey: string, fallbackMinutes: number) => {
+      const session = paintSessionRef.current;
+      if (!session) {
+        return;
+      }
+
+      const slotElement = getSlotElementFromPoint(clientX, clientY);
+      const nextSlot = slotElement ? getSlotCoordinatesFromElement(slotElement) : null;
+
+      if (nextSlot) {
+        paintCellInSession(session, nextSlot.dateKey, nextSlot.minutes);
+        return;
+      }
+
+      paintCellInSession(session, fallbackDateKey, fallbackMinutes);
+    },
+    [paintCellInSession],
+  );
+
+  const endPaintSession = useCallback((pointerId?: number) => {
+    const session = paintSessionRef.current;
+    if (!session) {
+      return;
+    }
+
+    if (pointerId !== undefined && session.pointerId !== pointerId) {
+      return;
+    }
+
+    paintSessionRef.current = null;
+  }, []);
+
+  const handleCellPointerDown = useCallback(
+    (
+      event: ReactPointerEvent<HTMLButtonElement>,
+      dateKey: string,
+      minutes: number,
+      isSelectedByCurrentUser: boolean,
+    ) => {
+      if (!event.isPrimary || mode !== "edit" || !supportsPainting) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const nextValue = !isSelectedByCurrentUser;
+      const nextSession: PaintSession = {
+        pointerId: event.pointerId,
+        value: nextValue,
+        paintedKeys: new Set(),
+      };
+
+      paintSessionRef.current = nextSession;
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+      paintCellInSession(nextSession, dateKey, minutes);
+    },
+    [mode, paintCellInSession, supportsPainting],
+  );
+
+  const handleCellPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>, dateKey: string, minutes: number) => {
+      const session = paintSessionRef.current;
+      if (!session || session.pointerId !== event.pointerId) {
+        return;
+      }
+
+      event.preventDefault();
+      continuePaintSession(event.clientX, event.clientY, dateKey, minutes);
+    },
+    [continuePaintSession],
+  );
+
+  const handleCellPointerEnd = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>, dateKey: string, minutes: number) => {
+      const session = paintSessionRef.current;
+      if (!session || session.pointerId !== event.pointerId) {
+        return;
+      }
+
+      continuePaintSession(event.clientX, event.clientY, dateKey, minutes);
+
+      if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+        event.currentTarget.releasePointerCapture?.(event.pointerId);
+      }
+
+      endPaintSession(event.pointerId);
+    },
+    [continuePaintSession, endPaintSession],
+  );
+
+  function toggleParticipantHighlight(participantId: string) {
+    setActiveParticipantId((current) => (current === participantId ? null : participantId));
+  }
+
+  function participantList() {
+    return (
+      <div className="space-y-2">
+        {snapshot.participants.map((participant) => (
+          <button
+            key={participant.id}
+            type="button"
+            aria-pressed={activeParticipantId === participant.id}
+            className={cn(
+              "flex w-full items-center justify-between gap-3 rounded-md border bg-muted/20 px-3 py-2 text-left transition-colors hover:bg-muted/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+              activeParticipantId === participant.id
+                ? "border-foreground/10 bg-background/90 shadow-sm"
+                : "",
+            )}
+            onClick={() => toggleParticipantHighlight(participant.id)}
+          >
+            <div className="flex items-center gap-3">
+              <span
+                className="size-2.5 rounded-full shadow-sm"
+                style={{ background: participant.color }}
+              />
+              <div>
+                <p className="text-sm font-medium text-foreground">
+                  {participant.displayName}
+                  {participant.isCurrentUser ? " (you)" : ""}
+                </p>
+                <p className="text-[11px] text-muted-foreground">
+                  {participant.selectedSlotCount} selected slots
+                </p>
+              </div>
+            </div>
+            {activeParticipantId === participant.id ? (
+              <span className="text-[11px] font-medium text-muted-foreground">Highlighting</span>
+            ) : null}
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  const description = (getDescription ?? getDefaultDescription)({
+    mode,
+    usesDateWindowing,
+  });
+
+  return (
+    <div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(0,1fr)_250px]">
+      <div className="min-w-0 space-y-4">
+        <Card className="min-w-0 overflow-hidden">
+          <CardHeader className="gap-3 p-4">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-center gap-2 text-[10px] font-medium tracking-[0.16em] text-muted-foreground uppercase">
+                  <span className="inline-flex items-center gap-1">
+                    <CalendarDaysIcon className="size-3" />
+                    {snapshot.dates.length} days
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <Clock3Icon className="size-3" />
+                    {snapshot.slotMinutes}-minute grid
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <UsersIcon className="size-3" />
+                    {snapshot.participants.length} participants
+                  </span>
+                </div>
+                <div>
+                  <CardTitle className="text-2xl">{snapshot.title}</CardTitle>
+                  <CardDescription className="mt-1 text-xs">
+                    Times shown in{" "}
+                    <span className="font-medium text-foreground">{snapshot.timezone}</span>
+                  </CardDescription>
+                </div>
+              </div>
+              {displayStatus === "CLOSED" ? (
+                <Badge variant="destructive" className="h-7 px-2.5 text-xs">
+                  <LockIcon className="size-3.5" />
+                  Closed
+                </Badge>
+              ) : null}
+            </div>
+
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-3">
+              <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
+                <span className="font-medium">Legend</span>
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="size-3 rounded-[3px] border bg-background" />
+                  empty
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  <span className="size-3 rounded-[3px] bg-primary/24" />
+                  some overlap
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  <span className="size-3 rounded-[3px] bg-primary/65" />
+                  high overlap
+                </span>
+                {supportsPainting && mode === "edit" ? (
+                  <span className="inline-flex items-center gap-1">
+                    <span className="size-3 rounded-[3px] bg-primary/24 outline outline-2 -outline-offset-2 outline-primary/85 ring-1 ring-inset ring-background" />
+                    your availability
+                  </span>
+                ) : null}
+                {finalizedSlot ? (
+                  <span className="inline-flex items-center gap-1">
+                    <span className="size-3 rounded-[3px] shadow-[inset_0_0_0_9999px_rgba(245,158,11,0.24)] ring-1 ring-inset ring-amber-500/70" />
+                    fixed date
+                  </span>
+                ) : null}
+                {activeParticipant ? (
+                  <span className="inline-flex items-center gap-1">
+                    <span
+                      className="size-3 rounded-[3px] border bg-background"
+                      style={getParticipantHighlightStyle({
+                        isHighlighted: true,
+                        participantColor: activeParticipant.color,
+                      })}
+                    />
+                    {activeParticipant.displayName} highlighted
+                  </span>
+                ) : null}
+              </div>
+              <div className="flex items-center gap-2">
+                {sessionBadgeLabel ? (
+                  <Badge variant="secondary" className="h-7 px-2.5 text-xs">
+                    {sessionBadgeLabel}
+                  </Badge>
+                ) : null}
+                <Sheet>
+                  <SheetTrigger asChild>
+                    <Button variant="outline" size="sm" className="xl:hidden">
+                      Participants
+                    </Button>
+                  </SheetTrigger>
+                  <SheetContent side="bottom" className="max-h-[80vh] rounded-t-xl">
+                    <SheetHeader>
+                      <SheetTitle>Participants</SheetTitle>
+                    </SheetHeader>
+                    <div className="pb-6">{participantList()}</div>
+                  </SheetContent>
+                </Sheet>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="min-w-0 p-4 pt-0">
+            <div className="space-y-3">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <CardTitle className="text-base">Availability</CardTitle>
+                  <CardDescription className="text-xs">{description}</CardDescription>
+                </div>
+                {showModeToggle ? (
+                  <div className="inline-flex rounded-md border bg-muted/30 p-1">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={mode === "edit" ? "secondary" : "ghost"}
+                      className="h-7 px-3"
+                      aria-pressed={mode === "edit"}
+                      disabled={!supportsPainting}
+                      onClick={() => onModeChange?.("edit")}
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={mode === "view" ? "secondary" : "ghost"}
+                      className="h-7 px-3"
+                      aria-pressed={mode === "view"}
+                      onClick={() => onModeChange?.("view")}
+                    >
+                      View
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+
+              {usesDateWindowing ? (
+                <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/20 p-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon-xs"
+                    aria-label="Show previous days"
+                    disabled={!canShowPreviousDates}
+                    onClick={() => moveVisibleDateWindow(-1)}
+                  >
+                    <ChevronLeftIcon className="size-4" />
+                  </Button>
+                  <div className="min-w-0 flex-1 text-center">
+                    <p aria-live="polite" className="truncate text-xs font-medium text-foreground">
+                      {visibleRangeLabel}
+                    </p>
+                    <p className="text-[11px] text-muted-foreground">
+                      Days {clampedVisibleDateStartIndex + 1}
+                      {" - "}
+                      {clampedVisibleDateStartIndex + visibleDates.length} of {snapshot.dates.length}
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon-xs"
+                    aria-label="Show next days"
+                    disabled={!canShowNextDates}
+                    onClick={() => moveVisibleDateWindow(1)}
+                  >
+                    <ChevronRightIcon className="size-4" />
+                  </Button>
+                </div>
+              ) : null}
+
+              <div ref={gridContainerRef} className="min-w-0 overflow-hidden rounded-md border">
+                <div
+                  className={cn(
+                    "grid gap-px bg-border select-none",
+                    mode === "edit" && supportsPainting ? "touch-none" : "touch-pan-y",
+                  )}
+                  style={{
+                    gridTemplateColumns: `${GRID_TIME_COLUMN_WIDTH_PX}px repeat(${visibleDates.length}, minmax(${GRID_DAY_COLUMN_MIN_WIDTH_PX}px, 1fr))`,
+                  }}
+                >
+                  <div className="sticky left-0 top-0 z-30 bg-background" />
+                  {visibleDates.map((date) => {
+                    const parts = splitDateLabel(date.label);
+
+                    return (
+                      <div
+                        key={date.dateKey}
+                        className="sticky top-0 z-20 flex min-w-[84px] flex-col items-center justify-center bg-background px-2 py-1 text-center"
+                      >
+                        <span className="text-[11px] font-semibold leading-none text-foreground">
+                          {parts.weekday}
+                        </span>
+                        <span className="mt-0.5 text-[10px] leading-none text-muted-foreground">
+                          {parts.monthDay}
+                        </span>
+                      </div>
+                    );
+                  })}
+                  {snapshot.timeRows.map((timeRow) => (
+                    <Fragment key={timeRow.minutes}>
+                      <div
+                        className={cn(
+                          "sticky left-0 z-10 flex items-center justify-end bg-background px-2 text-[11px] font-medium text-muted-foreground",
+                          cellHeightClass,
+                        )}
+                      >
+                        {isMajorTimeLabel(timeRow.minutes) ? timeRow.label : ""}
+                      </div>
+                      {visibleDates.map((date) => {
+                        const key = slotKey(date.dateKey, timeRow.minutes);
+                        const slot = slotMap.get(key);
+                        if (!slot) {
+                          return null;
+                        }
+
+                        const availableNames = slot.participantIds
+                          .map((participantId) => participantNamesById.get(participantId))
+                          .filter(Boolean) as string[];
+                        const availabilityTitle = availableNames.length
+                          ? `${date.label} ${timeRow.label} · ${slot.availabilityCount}/${snapshot.participants.length} available · ${availableNames.join(", ")}`
+                          : `${date.label} ${timeRow.label} · nobody available`;
+
+                        const isActiveViewSlot = mode === "view" && activeSlotKey === key;
+                        const showCurrentUserSelection = supportsPainting && mode === "edit" && slot.selectedByCurrentUser;
+                        const isHighlightedParticipantAvailable = activeParticipantId
+                          ? slot.participantIds.includes(activeParticipantId)
+                          : false;
+                        const isInFinalSlotWindow = finalizedSlotKeys.has(key);
+                        const isFinalSlotStart = finalizedSlot?.slotStart === slot.slotStart;
+
+                        return (
+                          <button
+                            key={key}
+                            type="button"
+                            aria-label={availabilityTitle}
+                            aria-pressed={mode === "edit" ? slot.selectedByCurrentUser : isActiveViewSlot}
+                            title={availabilityTitle}
+                            data-slot-key={key}
+                            data-date-key={date.dateKey}
+                            data-minutes={timeRow.minutes}
+                            data-current-user-selected={
+                              showCurrentUserSelection ? "true" : undefined
+                            }
+                            data-highlighted-participant-availability={
+                              isHighlightedParticipantAvailable ? "true" : undefined
+                            }
+                            data-final-slot-window={isInFinalSlotWindow ? "true" : undefined}
+                            data-final-slot-start={isFinalSlotStart ? "true" : undefined}
+                            className={cn(
+                              "min-w-[84px] border-0 transition-colors focus-visible:relative focus-visible:z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
+                              cellHeightClass,
+                              mode === "edit" && supportsPainting
+                                ? "cursor-crosshair touch-none hover:brightness-[0.98]"
+                                : "cursor-pointer hover:brightness-[0.99]",
+                              getHeatColor(slot.availabilityCount),
+                              getCurrentUserSelectionClass(showCurrentUserSelection),
+                              getActiveViewSelectionClass(isActiveViewSlot),
+                              getFinalizedSlotClass({
+                                isInFinalSlotWindow,
+                                isFinalSlotStart,
+                              }),
+                            )}
+                            style={getParticipantHighlightStyle({
+                              isHighlighted: isHighlightedParticipantAvailable,
+                              participantColor: activeParticipantId
+                                ? participantColorById.get(activeParticipantId)
+                                : undefined,
+                            })}
+                            onPointerDown={(event) =>
+                              handleCellPointerDown(
+                                event,
+                                date.dateKey,
+                                timeRow.minutes,
+                                slot.selectedByCurrentUser,
+                              )
+                            }
+                            onPointerMove={(event) =>
+                              handleCellPointerMove(event, date.dateKey, timeRow.minutes)
+                            }
+                            onPointerUp={(event) =>
+                              handleCellPointerEnd(event, date.dateKey, timeRow.minutes)
+                            }
+                            onPointerCancel={(event) =>
+                              handleCellPointerEnd(event, date.dateKey, timeRow.minutes)
+                            }
+                            onLostPointerCapture={(event) => {
+                              endPaintSession(event.pointerId);
+                            }}
+                            onClick={() => {
+                              if (mode !== "view") {
+                                return;
+                              }
+
+                              setActiveSlotKey(key);
+                            }}
+                          >
+                            <span className="sr-only">{availabilityTitle}</span>
+                          </button>
+                        );
+                      })}
+                    </Fragment>
+                  ))}
+                </div>
+              </div>
+            </div>
+            {mode === "view" ? (
+              <div className="mt-4 rounded-md border bg-muted/10 p-4">
+                <div className="space-y-1">
+                  <h3 className="text-sm font-semibold text-foreground">Slot details</h3>
+                  {activeSlotDetails ? (
+                    <p className="text-xs text-muted-foreground">
+                      {activeSlotDetails.dateLabel} · {activeSlotDetails.timeLabel} ·{" "}
+                      {activeSlotDetails.slot.availabilityCount}/{snapshot.participants.length} available
+                    </p>
+                  ) : (
+                    <p className="text-xs text-muted-foreground">
+                      Select a slot in the heatmap to inspect availability for that time.
+                    </p>
+                  )}
+                </div>
+
+                {activeSlotDetails ? (
+                  <div className="mt-4 space-y-4">
+                    <div className="grid gap-4 lg:grid-cols-2">
+                      <div className="space-y-2">
+                        <h4 className="text-xs font-medium tracking-[0.14em] text-muted-foreground uppercase">
+                          Available
+                        </h4>
+                        {activeSlotDetails.availableParticipants.length ? (
+                          <div className="space-y-2">
+                            {activeSlotDetails.availableParticipants.map((participant) => (
+                              <div
+                                key={participant.id}
+                                className="flex items-center gap-3 rounded-md border bg-background/80 px-3 py-2"
+                              >
+                                <span
+                                  className="size-2.5 rounded-full shadow-sm"
+                                  style={{ background: participant.color }}
+                                />
+                                <span className="text-sm font-medium text-foreground">
+                                  {participant.displayName}
+                                  {participant.isCurrentUser ? " (you)" : ""}
+                                </span>
+                              </div>
+                            ))}
+                          </div>
+                        ) : (
+                          <p className="text-sm text-muted-foreground">Nobody is available in this slot.</p>
+                        )}
+                      </div>
+                      <div className="space-y-2">
+                        <h4 className="text-xs font-medium tracking-[0.14em] text-muted-foreground uppercase">
+                          Not available
+                        </h4>
+                        {activeSlotDetails.unavailableParticipants.length ? (
+                          <div className="space-y-2">
+                            {activeSlotDetails.unavailableParticipants.map((participant) => (
+                              <div
+                                key={participant.id}
+                                className="flex items-center gap-3 rounded-md border border-dashed bg-background/60 px-3 py-2"
+                              >
+                                <span
+                                  className="size-2.5 rounded-full opacity-65 shadow-sm"
+                                  style={{ background: participant.color }}
+                                />
+                                <span className="text-sm font-medium text-foreground">
+                                  {participant.displayName}
+                                  {participant.isCurrentUser ? " (you)" : ""}
+                                </span>
+                              </div>
+                            ))}
+                          </div>
+                        ) : (
+                          <p className="text-sm text-muted-foreground">
+                            Everyone with at least one selection is available here.
+                          </p>
+                        )}
+                      </div>
+                    </div>
+
+                    {allowFinalSlotSelection ? (
+                      <div className="rounded-md border bg-background/70 p-3">
+                        {activeSlotDetails.isValidFinalSlotStart ? (
+                          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <div className="space-y-1">
+                              <p className="text-sm font-medium text-foreground">
+                                This slot fits the full {snapshot.meetingDurationMinutes}-minute meeting.
+                              </p>
+                              <p className="text-xs text-muted-foreground">
+                                Pick it as the fixed date for the closed event.
+                              </p>
+                            </div>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant={activeSlotDetails.isFinalSlotStart ? "secondary" : "default"}
+                              onClick={() => onFinalSlotSelect?.(activeSlotDetails.slot.slotStart)}
+                            >
+                              {activeSlotDetails.isFinalSlotStart ? "Fixed date selected" : "Set fixed date"}
+                            </Button>
+                          </div>
+                        ) : (
+                          <p className="text-xs text-muted-foreground">
+                            This start time does not fit the full {snapshot.meetingDurationMinutes}-minute
+                            meeting inside the selected day window.
+                          </p>
+                        )}
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+      </div>
+
+      <aside className="hidden min-w-0 space-y-4 xl:block">
+        {sidebarTopContent}
+
+        <Card>
+          <CardHeader className="p-4 pb-2">
+            <CardTitle className="text-sm">Participants</CardTitle>
+            <CardDescription className="text-xs">
+              Click a participant to highlight their availability on the grid.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="p-4 pt-0">{participantList()}</CardContent>
+        </Card>
+      </aside>
+    </div>
+  );
+}

--- a/src/components/manage-event-client.test.tsx
+++ b/src/components/manage-event-client.test.tsx
@@ -1,10 +1,16 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { ManageEventClient } from "./manage-event-client";
 import type { ManageEventView } from "@/lib/types";
 
-function createManageView(): ManageEventView {
+function createManageView(options?: {
+  status?: "OPEN" | "CLOSED";
+  finalizedSlot?: ManageEventView["snapshot"]["finalizedSlot"];
+}): ManageEventView {
+  const status = options?.status ?? "OPEN";
+  const finalizedSlot = options?.finalizedSlot ?? null;
+
   return {
     manageKey: "cmn8tbq86000001pbddo4sxf.a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
     shareUrl: "https://tempoll.app/e/test-event-xeqlxw",
@@ -15,14 +21,43 @@ function createManageView(): ManageEventView {
       slug: "test-event-xeqlxw",
       title: "Team sync",
       timezone: "Europe/Vienna",
-      status: "OPEN",
+      status,
       slotMinutes: 30,
       meetingDurationMinutes: 60,
       dayStartMinutes: 9 * 60,
-      dayEndMinutes: 17 * 60,
-      dates: [],
-      timeRows: [],
-      slots: [],
+      dayEndMinutes: 11 * 60,
+      dates: [{ dateKey: "2026-04-02", label: "Thu, Apr 2" }],
+      timeRows: [
+        { minutes: 9 * 60, label: "09:00" },
+        { minutes: 9 * 60 + 30, label: "09:30" },
+        { minutes: 10 * 60, label: "10:00" },
+      ],
+      slots: [
+        {
+          slotStart: "2026-04-02T07:00:00.000Z",
+          dateKey: "2026-04-02",
+          minutes: 9 * 60,
+          availabilityCount: 2,
+          participantIds: ["participant_1", "participant_2"],
+          selectedByCurrentUser: false,
+        },
+        {
+          slotStart: "2026-04-02T07:30:00.000Z",
+          dateKey: "2026-04-02",
+          minutes: 9 * 60 + 30,
+          availabilityCount: 2,
+          participantIds: ["participant_1", "participant_2"],
+          selectedByCurrentUser: false,
+        },
+        {
+          slotStart: "2026-04-02T08:00:00.000Z",
+          dateKey: "2026-04-02",
+          minutes: 10 * 60,
+          availabilityCount: 1,
+          participantIds: ["participant_1"],
+          selectedByCurrentUser: false,
+        },
+      ],
       participants: [
         {
           id: "participant_1",
@@ -31,18 +66,26 @@ function createManageView(): ManageEventView {
           selectedSlotCount: 3,
           isCurrentUser: false,
         },
+        {
+          id: "participant_2",
+          displayName: "Nora",
+          color: "#6b8afd",
+          selectedSlotCount: 2,
+          isCurrentUser: false,
+        },
       ],
       suggestions: [
         {
-          slotStart: "2026-04-02T11:30:00.000Z",
-          slotEnd: "2026-04-02T12:30:00.000Z",
+          slotStart: "2026-04-02T07:00:00.000Z",
+          slotEnd: "2026-04-02T08:00:00.000Z",
           dateKey: "2026-04-02",
-          label: "Thu, Apr 2 · 13:30-14:30",
-          localLabel: "Thu, Apr 2 · 13:30-14:30",
-          availableCount: 3,
-          participantIds: ["participant_1"],
+          label: "Thu, Apr 2 · 09:00-10:00",
+          localLabel: null,
+          availableCount: 2,
+          participantIds: ["participant_1", "participant_2"],
         },
       ],
+      finalizedSlot,
       currentParticipant: null,
     },
   };
@@ -51,13 +94,55 @@ function createManageView(): ManageEventView {
 describe("ManageEventClient", () => {
   it("keeps long share links wrappable inside the sidebar cards", () => {
     const view = createManageView();
-    const { container } = render(<ManageEventClient initialView={view} />);
+    render(<ManageEventClient initialView={view} />);
 
-    const layout = container.firstElementChild;
-
-    expect(layout?.className).toContain("xl:grid-cols-[minmax(0,1fr)_340px]");
     expect(screen.getByText(view.shareUrl).className).toContain("[overflow-wrap:anywhere]");
     expect(screen.getByText(view.manageUrl).className).toContain("[overflow-wrap:anywhere]");
+  });
+
+  it("renders the heatmap and lets the organizer select a fixed date on closed events", () => {
+    const view = createManageView({ status: "CLOSED" });
+    render(<ManageEventClient initialView={view} />);
+
+    expect(screen.getByText("Availability")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Thu, Apr 2 09:00 · 2\/2 available/i,
+      }),
+    );
+
+    expect(
+      screen.getByText("This slot fits the full 60-minute meeting."),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Set fixed date" }));
+
+    expect(screen.getByText("Fixed date")).toBeInTheDocument();
+    expect(screen.getByText("Thu, Apr 2 · 09:00-10:00")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled();
+  });
+
+  it("shows the saved fixed date with an .ics export link", () => {
+    const view = createManageView({
+      status: "CLOSED",
+      finalizedSlot: {
+        slotStart: "2026-04-02T07:00:00.000Z",
+        slotEnd: "2026-04-02T08:00:00.000Z",
+        dateKey: "2026-04-02",
+        label: "Thu, Apr 2 · 09:00-10:00",
+        localLabel: null,
+        availableCount: 2,
+        participantIds: ["participant_1", "participant_2"],
+      },
+    });
+    render(<ManageEventClient initialView={view} />);
+
+    expect(screen.getByText("Fixed date")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Add to calendar (.ics)" })).toHaveAttribute(
+      "href",
+      "/api/events/test-event-xeqlxw/ics",
+    );
   });
 
   it("hides best windows before anyone has entered availability", () => {

--- a/src/components/manage-event-client.tsx
+++ b/src/components/manage-event-client.tsx
@@ -2,9 +2,10 @@
 
 import Link from "next/link";
 import { Loader2Icon, Trash2Icon } from "lucide-react";
-import { useEffect, useState, useTransition } from "react";
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
 
+import { EventHeatmap } from "@/components/event-heatmap";
 import { CopyButton } from "@/components/copy-button";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -17,6 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { buildFinalizedSlot } from "@/lib/availability";
 import type { ManageEventView, PublicEventSnapshot } from "@/lib/types";
 
 type ManageEventClientProps = {
@@ -27,32 +29,72 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
   const [snapshot, setSnapshot] = useState<PublicEventSnapshot>(initialView.snapshot);
   const [title, setTitle] = useState(initialView.snapshot.title);
   const [status, setStatus] = useState(initialView.snapshot.status);
+  const [finalSlotStart, setFinalSlotStart] = useState<string | null>(
+    initialView.snapshot.finalizedSlot?.slotStart ?? null,
+  );
   const [isPending, startTransition] = useTransition();
   const hasAnyAvailability = snapshot.participants.some(
     (participant) => participant.selectedSlotCount > 0,
   );
+  const draftFinalizedSlot = useMemo(() => {
+    if (status !== "CLOSED" || !finalSlotStart) {
+      return null;
+    }
+
+    return buildFinalizedSlot({
+      dates: snapshot.dates.map((date) => date.dateKey),
+      timezone: snapshot.timezone,
+      dayStartMinutes: snapshot.dayStartMinutes,
+      dayEndMinutes: snapshot.dayEndMinutes,
+      slotMinutes: snapshot.slotMinutes,
+      meetingDurationMinutes: snapshot.meetingDurationMinutes,
+      slots: snapshot.slots,
+      finalSlotStart,
+    });
+  }, [
+    finalSlotStart,
+    snapshot.dates,
+    snapshot.dayEndMinutes,
+    snapshot.dayStartMinutes,
+    snapshot.meetingDurationMinutes,
+    snapshot.slotMinutes,
+    snapshot.slots,
+    snapshot.timezone,
+    status,
+  ]);
+  const isClosingWithoutFixedDate = status === "CLOSED" && !draftFinalizedSlot;
+
+  const refreshSnapshot = useCallback(async () => {
+    const response = await fetch(`/api/events/${initialView.snapshot.slug}`, {
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      return;
+    }
+
+    const payload = (await response.json()) as { snapshot: PublicEventSnapshot };
+    setSnapshot(payload.snapshot);
+    setTitle(payload.snapshot.title);
+    setStatus(payload.snapshot.status);
+    setFinalSlotStart(payload.snapshot.finalizedSlot?.slotStart ?? null);
+  }, [initialView.snapshot.slug]);
 
   useEffect(() => {
     const eventSource = new EventSource(`/api/events/${initialView.snapshot.slug}/stream`);
-    eventSource.addEventListener("event-update", async () => {
-      const response = await fetch(`/api/events/${initialView.snapshot.slug}`, {
-        cache: "no-store",
-      });
-
-      if (!response.ok) {
-        return;
-      }
-
-      const payload = (await response.json()) as { snapshot: PublicEventSnapshot };
-      setSnapshot(payload.snapshot);
-      setTitle(payload.snapshot.title);
-      setStatus(payload.snapshot.status);
+    eventSource.addEventListener("event-update", () => {
+      void refreshSnapshot();
     });
 
     return () => eventSource.close();
-  }, [initialView.snapshot.slug]);
+  }, [initialView.snapshot.slug, refreshSnapshot]);
 
   function updateEvent() {
+    if (isClosingWithoutFixedDate) {
+      toast.error("Pick a fixed date before closing this event.");
+      return;
+    }
+
     startTransition(async () => {
       const response = await fetch(`/api/manage/${initialView.manageKey}`, {
         method: "PATCH",
@@ -63,6 +105,7 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
           action: "updateEvent",
           title,
           status,
+          finalSlotStart: status === "CLOSED" ? finalSlotStart : null,
         }),
       });
 
@@ -73,11 +116,7 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
       }
 
       toast.success("Event updated");
-      setSnapshot((current) => ({
-        ...current,
-        title,
-        status,
-      }));
+      await refreshSnapshot();
     });
   }
 
@@ -127,54 +166,146 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
       }
 
       toast.success("Participant removed");
-      setSnapshot((current) => ({
-        ...current,
-        participants: current.participants.filter((participant) => participant.id !== participantId),
-      }));
+      await refreshSnapshot();
     });
   }
 
-  return (
-    <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_340px]">
-      <div className="min-w-0 space-y-6">
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-3xl">Manage event</CardTitle>
-            <CardDescription>
-              Share the public board, keep the private organizer URL safe and
-              control whether new changes are still allowed.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="grid gap-6 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="title">Title</Label>
-              <Input
-                id="title"
-                value={title}
-                onChange={(event) => setTitle(event.target.value)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label>Status</Label>
-              <Select value={status} onValueChange={(value) => setStatus(value as "OPEN" | "CLOSED")}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="OPEN">Open for edits</SelectItem>
-                  <SelectItem value="CLOSED">Closed</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="md:col-span-2">
-              <Button onClick={updateEvent} disabled={isPending} className="h-10">
-                {isPending ? <Loader2Icon className="size-4 animate-spin" /> : null}
-                Save changes
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+  function handleStatusChange(nextStatus: "OPEN" | "CLOSED") {
+    setStatus(nextStatus);
+    if (nextStatus === "OPEN") {
+      setFinalSlotStart(null);
+    }
+  }
 
+  const savedFinalSlot = snapshot.status === "CLOSED" ? snapshot.finalizedSlot : null;
+  const hasSavedFixedDate =
+    Boolean(savedFinalSlot) && savedFinalSlot?.slotStart === draftFinalizedSlot?.slotStart;
+  const bestWindowsCard = hasAnyAvailability ? (
+    <Card>
+      <CardHeader className="p-4 pb-2">
+        <CardTitle className="text-sm">Best windows right now</CardTitle>
+        <CardDescription className="text-xs">
+          Ranked by overlap across the full {snapshot.meetingDurationMinutes}-minute meeting.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2 p-4 pt-0">
+        {snapshot.suggestions.map((suggestion, index) => (
+          <div key={suggestion.slotStart} className="rounded-md border bg-muted/20 px-3 py-2">
+            <p className="text-[11px] font-medium text-muted-foreground">Option {index + 1}</p>
+            <p className="mt-1 text-sm font-semibold text-foreground">{suggestion.label}</p>
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              {suggestion.availableCount} people available
+            </p>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  ) : null;
+  const sidebarTopContent = draftFinalizedSlot ? (
+    <>
+      <Card>
+        <CardHeader className="p-4 pb-2">
+          <CardTitle className="text-sm">Fixed date</CardTitle>
+          <CardDescription className="text-xs">
+            {hasSavedFixedDate
+              ? "This is the published fixed date for the closed event."
+              : "This fixed date is selected locally and will be published after saving."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3 p-4 pt-0">
+          <div className="rounded-md border bg-muted/20 px-3 py-2">
+            <p className="text-sm font-semibold text-foreground">{draftFinalizedSlot.label}</p>
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              {draftFinalizedSlot.availableCount} participants free for the full window
+            </p>
+          </div>
+          <div className="flex flex-col gap-2">
+            {hasSavedFixedDate ? (
+              <Button asChild size="sm" className="w-full">
+                <a href={`/api/events/${snapshot.slug}/ics`}>Add to calendar (.ics)</a>
+              </Button>
+            ) : null}
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="w-full"
+              onClick={() => setFinalSlotStart(null)}
+            >
+              Clear fixed date
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+      {bestWindowsCard}
+    </>
+  ) : (
+    bestWindowsCard
+  );
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-3xl">Manage event</CardTitle>
+          <CardDescription>
+            Share the public board, keep the private organizer URL safe, control whether new changes
+            are still allowed and set the fixed date before closing the event.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-6 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="title">Title</Label>
+            <Input id="title" value={title} onChange={(event) => setTitle(event.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label>Status</Label>
+            <Select value={status} onValueChange={(value) => handleStatusChange(value as "OPEN" | "CLOSED")}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="OPEN">Open for edits</SelectItem>
+                <SelectItem value="CLOSED">Closed</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="md:col-span-2 space-y-3">
+            <Button onClick={updateEvent} disabled={isPending || isClosingWithoutFixedDate} className="h-10">
+              {isPending ? <Loader2Icon className="size-4 animate-spin" /> : null}
+              Save changes
+            </Button>
+            {isClosingWithoutFixedDate ? (
+              <p className="text-sm text-destructive">
+                Pick a fixed date in the heatmap before closing this event.
+              </p>
+            ) : null}
+          </div>
+        </CardContent>
+      </Card>
+
+      <EventHeatmap
+        snapshot={snapshot}
+        mode="view"
+        canEdit={false}
+        showModeToggle={false}
+        displayStatus={status}
+        finalSlotStart={status === "CLOSED" ? finalSlotStart : null}
+        allowFinalSlotSelection={status === "CLOSED"}
+        onFinalSlotSelect={setFinalSlotStart}
+        sidebarTopContent={sidebarTopContent}
+        getDescription={({ usesDateWindowing }) =>
+          status === "CLOSED"
+            ? usesDateWindowing
+              ? "Select a slot to inspect overlap and use the button below to set the fixed date. Use the arrows to move through the date range."
+              : "Click any slot to inspect availability and set the fixed date for this closed event."
+            : usesDateWindowing
+              ? "Select a slot to inspect availability. Close the event to choose the fixed date."
+              : "Click any slot to inspect availability. Close the event when you are ready to choose the fixed date."
+        }
+      />
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_340px]">
         <Card>
           <CardHeader>
             <CardTitle>Participants</CardTitle>
@@ -184,10 +315,7 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
           </CardHeader>
           <CardContent className="space-y-4">
             {snapshot.participants.map((participant) => (
-              <div
-                key={participant.id}
-                className="rounded-lg border bg-muted/20 p-4"
-              >
+              <div key={participant.id} className="rounded-lg border bg-muted/20 p-4">
                 <div className="flex items-center gap-3">
                   <span
                     className="size-3 rounded-full shadow-sm"
@@ -218,63 +346,39 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
             ))}
           </CardContent>
         </Card>
-      </div>
 
-      <aside className="min-w-0 space-y-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>Share links</CardTitle>
-            <CardDescription>
-              Keep the organizer link private. The public link is safe to share.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <Label>Public event URL</Label>
-              <div className="rounded-md border bg-muted/20 px-4 py-3 text-sm text-muted-foreground [overflow-wrap:anywhere]">
-                {initialView.shareUrl}
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <Button asChild>
-                  <Link href={initialView.shareUrl}>Open public event</Link>
-                </Button>
-                <CopyButton value={initialView.shareUrl} label="Copy public URL" />
-              </div>
-            </div>
-            <div className="space-y-2">
-              <Label>Private organizer URL</Label>
-              <div className="rounded-md border bg-muted/20 px-4 py-3 text-sm text-muted-foreground [overflow-wrap:anywhere]">
-                {initialView.manageUrl}
-              </div>
-              <CopyButton value={initialView.manageUrl} label="Copy organizer URL" />
-            </div>
-          </CardContent>
-        </Card>
-
-        {hasAnyAvailability ? (
+        <aside className="min-w-0 space-y-6">
           <Card>
             <CardHeader>
-              <CardTitle>Best windows right now</CardTitle>
+              <CardTitle>Share links</CardTitle>
+              <CardDescription>
+                Keep the organizer link private. The public link is safe to share.
+              </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-3">
-              {snapshot.suggestions.map((suggestion, index) => (
-                <div
-                  key={suggestion.slotStart}
-                  className="rounded-lg border bg-muted/20 px-4 py-3"
-                >
-                  <p className="text-xs font-medium text-muted-foreground">
-                    Option {index + 1}
-                  </p>
-                  <p className="mt-2 text-sm font-semibold">{suggestion.label}</p>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {suggestion.availableCount} people available
-                  </p>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label>Public event URL</Label>
+                <div className="rounded-md border bg-muted/20 px-4 py-3 text-sm text-muted-foreground [overflow-wrap:anywhere]">
+                  {initialView.shareUrl}
                 </div>
-              ))}
+                <div className="flex flex-wrap gap-2">
+                  <Button asChild>
+                    <Link href={initialView.shareUrl}>Open public event</Link>
+                  </Button>
+                  <CopyButton value={initialView.shareUrl} label="Copy public URL" />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label>Private organizer URL</Label>
+                <div className="rounded-md border bg-muted/20 px-4 py-3 text-sm text-muted-foreground [overflow-wrap:anywhere]">
+                  {initialView.manageUrl}
+                </div>
+                <CopyButton value={initialView.manageUrl} label="Copy organizer URL" />
+              </div>
             </CardContent>
           </Card>
-        ) : null}
-      </aside>
+        </aside>
+      </div>
     </div>
   );
 }

--- a/src/components/public-event-client.test.tsx
+++ b/src/components/public-event-client.test.tsx
@@ -8,6 +8,7 @@ function createSnapshot(options?: {
   status?: PublicEventSnapshot["status"];
   withCurrentUser?: boolean;
   dayCount?: number;
+  finalizedSlot?: PublicEventSnapshot["finalizedSlot"];
 }): PublicEventSnapshot {
   const status = options?.status ?? "OPEN";
   const withCurrentUser = options?.withCurrentUser ?? true;
@@ -87,6 +88,7 @@ function createSnapshot(options?: {
       isCurrentUser: withCurrentUser && participant.id === "p1",
     })),
     suggestions: [],
+    finalizedSlot: options?.finalizedSlot ?? null,
     currentParticipant: withCurrentUser
       ? {
           id: "p1",
@@ -342,5 +344,57 @@ describe("PublicEventClient", () => {
 
     expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "View" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows the fixed date and marks it on the heatmap for closed events", () => {
+    const snapshot = createSnapshot({
+      status: "CLOSED",
+      finalizedSlot: {
+        slotStart: "2026-03-30T07:00:00.000Z",
+        slotEnd: "2026-03-30T08:00:00.000Z",
+        dateKey: "2026-03-30",
+        label: "Mon, Mar 30 · 09:00-10:00",
+        localLabel: null,
+        availableCount: 1,
+        participantIds: ["p2"],
+      },
+    });
+    snapshot.suggestions = [
+      {
+        slotStart: "2026-03-31T07:00:00.000Z",
+        slotEnd: "2026-03-31T08:00:00.000Z",
+        dateKey: "2026-03-31",
+        label: "Tue, Mar 31 · 09:00-10:00",
+        localLabel: null,
+        availableCount: 2,
+        participantIds: ["p2", "p3"],
+      },
+    ];
+
+    render(
+      <PublicEventClient
+        slug="test-event"
+        initialSnapshot={snapshot}
+        initialSession={null}
+      />,
+    );
+
+    expect(screen.getByText("Fixed date")).toBeInTheDocument();
+    expect(screen.queryByText("Best matching windows")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Add to calendar (.ics)" })).toHaveAttribute(
+      "href",
+      "/api/events/test-event/ics",
+    );
+
+    const firstCell = screen.getByRole("button", {
+      name: /Mon, Mar 30 09:00 · 2\/4 available/i,
+    });
+    const secondCell = screen.getByRole("button", {
+      name: /Mon, Mar 30 09:30 · 1\/4 available/i,
+    });
+
+    expect(firstCell).toHaveAttribute("data-final-slot-start", "true");
+    expect(firstCell).toHaveAttribute("data-final-slot-window", "true");
+    expect(secondCell).toHaveAttribute("data-final-slot-window", "true");
   });
 });

--- a/src/components/public-event-client.tsx
+++ b/src/components/public-event-client.tsx
@@ -1,34 +1,15 @@
 "use client";
 
-import {
-  CalendarDaysIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  Clock3Icon,
-  Loader2Icon,
-  LockIcon,
-  UsersIcon,
-} from "lucide-react";
-import {
-  Fragment,
-  type CSSProperties,
-  type PointerEvent as ReactPointerEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { Loader2Icon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
-import { Badge } from "@/components/ui/badge";
+import { EventHeatmap, type BoardMode, type DraftSelection } from "@/components/event-heatmap";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import type { PublicEventSnapshot, RealtimeEventPayload } from "@/lib/types";
-import { cn } from "@/lib/utils";
 
 type PublicEventClientProps = {
   slug: string;
@@ -48,113 +29,13 @@ type ParticipantSessionState =
     }
   | null;
 
-type DraftSelection = Record<string, boolean>;
-type BoardMode = "edit" | "view";
-type PaintSession = {
-  pointerId: number;
-  value: boolean;
-  paintedKeys: Set<string>;
-};
-
-const GRID_TIME_COLUMN_WIDTH_PX = 72;
-const GRID_DAY_COLUMN_MIN_WIDTH_PX = 84;
-
-function slotKey(dateKey: string, minutes: number) {
-  return `${dateKey}-${minutes}`;
-}
-
 function getInitialMode(hasEditableSession: boolean): BoardMode {
   return hasEditableSession ? "edit" : "view";
 }
 
-function getHeatColor(availabilityCount: number) {
-  if (availabilityCount >= 6) {
-    return "bg-primary/80";
-  }
-
-  if (availabilityCount === 5) {
-    return "bg-primary/65";
-  }
-
-  if (availabilityCount === 4) {
-    return "bg-primary/50";
-  }
-
-  if (availabilityCount === 3) {
-    return "bg-primary/36";
-  }
-
-  if (availabilityCount === 2) {
-    return "bg-primary/24";
-  }
-
-  if (availabilityCount === 1) {
-    return "bg-primary/12";
-  }
-
-  return "bg-background";
-}
-
-function getCurrentUserSelectionClass(isSelected: boolean) {
-  if (!isSelected) {
-    return "";
-  }
-
-  return "outline outline-2 -outline-offset-2 outline-primary/85 ring-2 ring-inset ring-background";
-}
-
-function getActiveViewSelectionClass(isActive: boolean) {
-  if (!isActive) {
-    return "";
-  }
-
-  return "ring-2 ring-inset ring-foreground/20";
-}
-
-function getParticipantHighlightStyle({
-  isHighlighted,
-  participantColor,
-}: {
-  isHighlighted: boolean;
-  participantColor?: string;
-}): CSSProperties | undefined {
-  if (!isHighlighted || !participantColor) {
-    return undefined;
-  }
-
-  return {
-    backgroundImage: `linear-gradient(135deg, transparent 0%, transparent 56%, ${participantColor}99 56%, ${participantColor}99 69%, transparent 69%, transparent 100%)`,
-  };
-}
-
-function getCellHeightClass(slotMinutes: number) {
-  if (slotMinutes <= 15) {
-    return "h-4";
-  }
-
-  if (slotMinutes <= 30) {
-    return "h-5";
-  }
-
-  return "h-7";
-}
-
-function splitDateLabel(label: string) {
-  const [weekday, monthDay] = label.split(", ");
-
-  return {
-    weekday: weekday ?? label,
-    monthDay: monthDay ?? "",
-  };
-}
-
-function isMajorTimeLabel(minutes: number) {
-  return minutes % 60 === 0;
-}
-
 function getSelectedMap(snapshot: PublicEventSnapshot) {
   return snapshot.slots.reduce<DraftSelection>((acc, slot) => {
-    acc[slotKey(slot.dateKey, slot.minutes)] = slot.selectedByCurrentUser;
+    acc[`${slot.dateKey}-${slot.minutes}`] = slot.selectedByCurrentUser;
     return acc;
   }, {});
 }
@@ -163,79 +44,6 @@ function getSelectedSlotStarts(snapshot: PublicEventSnapshot) {
   return snapshot.slots
     .filter((slot) => slot.selectedByCurrentUser)
     .map((slot) => slot.slotStart);
-}
-
-function getVisibleDayCount(containerWidth: number, totalDays: number) {
-  if (totalDays === 0) {
-    return 0;
-  }
-
-  if (containerWidth <= 0) {
-    return totalDays;
-  }
-
-  const fullGridWidth = GRID_TIME_COLUMN_WIDTH_PX + totalDays * GRID_DAY_COLUMN_MIN_WIDTH_PX;
-  if (containerWidth >= fullGridWidth) {
-    return totalDays;
-  }
-
-  const availableWidth = Math.max(
-    containerWidth - GRID_TIME_COLUMN_WIDTH_PX,
-    GRID_DAY_COLUMN_MIN_WIDTH_PX,
-  );
-
-  return Math.max(1, Math.floor(availableWidth / GRID_DAY_COLUMN_MIN_WIDTH_PX));
-}
-
-function clampVisibleDateStartIndex(startIndex: number, totalDays: number, visibleDayCount: number) {
-  const maxStartIndex = Math.max(totalDays - visibleDayCount, 0);
-  return Math.min(Math.max(startIndex, 0), maxStartIndex);
-}
-
-function getVisibleRangeLabel(dates: PublicEventSnapshot["dates"]) {
-  if (!dates.length) {
-    return "";
-  }
-
-  if (dates.length === 1) {
-    return dates[0].label;
-  }
-
-  return `${dates[0].label} to ${dates[dates.length - 1].label}`;
-}
-
-function getSlotElementFromPoint(clientX: number, clientY: number) {
-  const elements =
-    typeof document.elementsFromPoint === "function"
-      ? document.elementsFromPoint(clientX, clientY)
-      : [document.elementFromPoint(clientX, clientY)].filter(Boolean);
-
-  for (const element of elements) {
-    if (!(element instanceof HTMLElement)) {
-      continue;
-    }
-
-    const slotElement = element.closest<HTMLElement>("[data-slot-key]");
-    if (slotElement instanceof HTMLButtonElement) {
-      return slotElement;
-    }
-  }
-
-  return null;
-}
-
-function getSlotCoordinatesFromElement(element: HTMLElement) {
-  const dateKey = element.dataset.dateKey;
-  const minutes = Number(element.dataset.minutes);
-  if (!dateKey || Number.isNaN(minutes)) {
-    return null;
-  }
-
-  return {
-    dateKey,
-    minutes,
-    key: element.dataset.slotKey ?? slotKey(dateKey, minutes),
-  };
 }
 
 export function PublicEventClient({
@@ -249,15 +57,9 @@ export function PublicEventClient({
   const [name, setName] = useState("");
   const [selectedMap, setSelectedMap] = useState(() => getSelectedMap(initialSnapshot));
   const [mode, setMode] = useState<BoardMode>(() => getInitialMode(initialHasEditableSession));
-  const [activeSlotKey, setActiveSlotKey] = useState<string | null>(null);
-  const [activeParticipantId, setActiveParticipantId] = useState<string | null>(null);
   const [joining, setJoining] = useState(false);
   const [joinError, setJoinError] = useState<string | null>(null);
   const [draftVersion, setDraftVersion] = useState(0);
-  const [gridContainerWidth, setGridContainerWidth] = useState(0);
-  const [visibleDateStartIndex, setVisibleDateStartIndex] = useState(0);
-  const gridContainerRef = useRef<HTMLDivElement | null>(null);
-  const paintSessionRef = useRef<PaintSession | null>(null);
   const localAvailabilityEchoRef = useRef<{
     participantId: string;
     expiresAt: number;
@@ -318,7 +120,7 @@ export function PublicEventClient({
 
     const handle = window.setTimeout(async () => {
       const selectedSlotStarts = snapshot.slots
-        .filter((slot) => selectedMap[slotKey(slot.dateKey, slot.minutes)])
+        .filter((slot) => selectedMap[`${slot.dateKey}-${slot.minutes}`])
         .map((slot) => slot.slotStart);
 
       queuedSelectedSlotStartsRef.current = selectedSlotStarts;
@@ -396,181 +198,8 @@ export function PublicEventClient({
   useEffect(() => {
     if (!canEdit) {
       setMode("view");
-      paintSessionRef.current = null;
     }
   }, [canEdit]);
-
-  useEffect(() => {
-    if (mode === "edit") {
-      setActiveSlotKey(null);
-    }
-  }, [mode]);
-
-  const measureGridContainer = useCallback(() => {
-    const nextWidth = gridContainerRef.current?.clientWidth || window.innerWidth;
-    setGridContainerWidth((current) => (current === nextWidth ? current : nextWidth));
-  }, []);
-
-  useEffect(() => {
-    measureGridContainer();
-
-    const handleResize = () => {
-      measureGridContainer();
-    };
-
-    window.addEventListener("resize", handleResize);
-
-    if (!gridContainerRef.current || typeof ResizeObserver === "undefined") {
-      return () => window.removeEventListener("resize", handleResize);
-    }
-
-    const observer = new ResizeObserver(() => {
-      measureGridContainer();
-    });
-    observer.observe(gridContainerRef.current);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-      observer.disconnect();
-    };
-  }, [measureGridContainer]);
-
-  useEffect(() => {
-    if (!activeParticipantId) {
-      return;
-    }
-
-    const participantExists = snapshot.participants.some((participant) => participant.id === activeParticipantId);
-    if (!participantExists) {
-      setActiveParticipantId(null);
-    }
-  }, [activeParticipantId, snapshot.participants]);
-
-  const currentParticipantId = session?.participantId ?? snapshot.currentParticipant?.id ?? null;
-  const slotMap = useMemo(
-    () =>
-      new Map(
-        snapshot.slots.map((slot) => {
-          const key = slotKey(slot.dateKey, slot.minutes);
-          const selectedByCurrentUser = selectedMap[key] ?? false;
-          let participantIds = slot.participantIds;
-
-          if (currentParticipantId) {
-            if (selectedByCurrentUser && !slot.selectedByCurrentUser) {
-              participantIds = slot.participantIds.includes(currentParticipantId)
-                ? slot.participantIds
-                : [...slot.participantIds, currentParticipantId];
-            } else if (!selectedByCurrentUser && slot.selectedByCurrentUser) {
-              participantIds = slot.participantIds.filter(
-                (participantId) => participantId !== currentParticipantId,
-              );
-            }
-          }
-
-          return [
-            key,
-            {
-              ...slot,
-              participantIds,
-              availabilityCount: participantIds.length,
-              selectedByCurrentUser,
-            },
-          ];
-        }),
-      ),
-    [currentParticipantId, selectedMap, snapshot.slots],
-  );
-  const dateLabelsByKey = useMemo(
-    () => new Map(snapshot.dates.map((date) => [date.dateKey, date.label])),
-    [snapshot.dates],
-  );
-  const timeLabelsByMinutes = useMemo(
-    () => new Map(snapshot.timeRows.map((timeRow) => [timeRow.minutes, timeRow.label])),
-    [snapshot.timeRows],
-  );
-  const participantNamesById = useMemo(
-    () => new Map(snapshot.participants.map((participant) => [participant.id, participant.displayName])),
-    [snapshot.participants],
-  );
-  const participantColorById = useMemo(
-    () => new Map(snapshot.participants.map((participant) => [participant.id, participant.color])),
-    [snapshot.participants],
-  );
-  const participantsWithAvailability = useMemo(
-    () => snapshot.participants.filter((participant) => participant.selectedSlotCount > 0),
-    [snapshot.participants],
-  );
-  const cellHeightClass = getCellHeightClass(snapshot.slotMinutes);
-  const visibleDayCount = useMemo(
-    () => getVisibleDayCount(gridContainerWidth, snapshot.dates.length),
-    [gridContainerWidth, snapshot.dates.length],
-  );
-  const usesDateWindowing = visibleDayCount > 0 && visibleDayCount < snapshot.dates.length;
-  const clampedVisibleDateStartIndex = useMemo(
-    () =>
-      clampVisibleDateStartIndex(visibleDateStartIndex, snapshot.dates.length, visibleDayCount || 1),
-    [visibleDateStartIndex, snapshot.dates.length, visibleDayCount],
-  );
-  const visibleDates = useMemo(() => {
-    if (!usesDateWindowing) {
-      return snapshot.dates;
-    }
-
-    return snapshot.dates.slice(
-      clampedVisibleDateStartIndex,
-      clampedVisibleDateStartIndex + visibleDayCount,
-    );
-  }, [clampedVisibleDateStartIndex, snapshot.dates, usesDateWindowing, visibleDayCount]);
-  const visibleDateKeys = useMemo(
-    () => new Set(visibleDates.map((date) => date.dateKey)),
-    [visibleDates],
-  );
-  const canShowPreviousDates = usesDateWindowing && clampedVisibleDateStartIndex > 0;
-  const canShowNextDates =
-    usesDateWindowing &&
-    clampedVisibleDateStartIndex + visibleDates.length < snapshot.dates.length;
-  const visibleRangeLabel = useMemo(() => getVisibleRangeLabel(visibleDates), [visibleDates]);
-  const activeParticipant =
-    activeParticipantId
-      ? snapshot.participants.find((participant) => participant.id === activeParticipantId) ?? null
-      : null;
-  const activeSlot = activeSlotKey ? (slotMap.get(activeSlotKey) ?? null) : null;
-  const activeSlotDetails = useMemo(() => {
-    if (!activeSlot) {
-      return null;
-    }
-
-    const availableSet = new Set(activeSlot.participantIds);
-
-    return {
-      slot: activeSlot,
-      dateLabel: dateLabelsByKey.get(activeSlot.dateKey) ?? activeSlot.dateKey,
-      timeLabel: timeLabelsByMinutes.get(activeSlot.minutes) ?? "",
-      availableParticipants: snapshot.participants.filter((participant) =>
-        availableSet.has(participant.id),
-      ),
-      unavailableParticipants: participantsWithAvailability.filter(
-        (participant) => !availableSet.has(participant.id),
-      ),
-    };
-  }, [activeSlot, dateLabelsByKey, participantsWithAvailability, snapshot.participants, timeLabelsByMinutes]);
-
-  useEffect(() => {
-    setVisibleDateStartIndex((current) =>
-      clampVisibleDateStartIndex(current, snapshot.dates.length, visibleDayCount || 1),
-    );
-  }, [snapshot.dates.length, visibleDayCount]);
-
-  useEffect(() => {
-    if (!activeSlotKey || mode !== "view") {
-      return;
-    }
-
-    const slot = slotMap.get(activeSlotKey);
-    if (!slot || !visibleDateKeys.has(slot.dateKey)) {
-      setActiveSlotKey(null);
-    }
-  }, [activeSlotKey, mode, slotMap, visibleDateKeys]);
 
   async function handleJoin() {
     setJoining(true);
@@ -611,7 +240,7 @@ export function PublicEventClient({
         return false;
       }
 
-      const key = slotKey(dateKey, minutes);
+      const key = `${dateKey}-${minutes}`;
       let didChange = false;
 
       setSelectedMap((current) => {
@@ -636,613 +265,101 @@ export function PublicEventClient({
     [canEdit],
   );
 
-  const moveVisibleDateWindow = useCallback(
-    (direction: -1 | 1) => {
-      setVisibleDateStartIndex((current) =>
-        clampVisibleDateStartIndex(current + direction, snapshot.dates.length, visibleDayCount || 1),
-      );
-    },
-    [snapshot.dates.length, visibleDayCount],
-  );
-
-  const paintCellInSession = useCallback(
-    (session: PaintSession, dateKey: string, minutes: number) => {
-      const key = slotKey(dateKey, minutes);
-      if (session.paintedKeys.has(key)) {
-        return;
-      }
-
-      session.paintedKeys.add(key);
-      updateCell(dateKey, minutes, session.value);
-    },
-    [updateCell],
-  );
-
-  const continuePaintSession = useCallback(
-    (clientX: number, clientY: number, fallbackDateKey: string, fallbackMinutes: number) => {
-      const session = paintSessionRef.current;
-      if (!session) {
-        return;
-      }
-
-      const slotElement = getSlotElementFromPoint(clientX, clientY);
-      const nextSlot =
-        slotElement ? getSlotCoordinatesFromElement(slotElement) : null;
-
-      if (nextSlot) {
-        paintCellInSession(session, nextSlot.dateKey, nextSlot.minutes);
-        return;
-      }
-
-      paintCellInSession(session, fallbackDateKey, fallbackMinutes);
-    },
-    [paintCellInSession],
-  );
-
-  const endPaintSession = useCallback((pointerId?: number) => {
-    const session = paintSessionRef.current;
-    if (!session) {
-      return;
-    }
-
-    if (pointerId !== undefined && session.pointerId !== pointerId) {
-      return;
-    }
-
-    paintSessionRef.current = null;
-  }, []);
-
-  const handleCellPointerDown = useCallback(
-    (
-      event: ReactPointerEvent<HTMLButtonElement>,
-      dateKey: string,
-      minutes: number,
-      isSelectedByCurrentUser: boolean,
-    ) => {
-      if (!event.isPrimary || mode !== "edit" || !canEdit) {
-        return;
-      }
-
-      event.preventDefault();
-
-      const nextValue = !isSelectedByCurrentUser;
-      const nextSession: PaintSession = {
-        pointerId: event.pointerId,
-        value: nextValue,
-        paintedKeys: new Set(),
-      };
-
-      paintSessionRef.current = nextSession;
-      event.currentTarget.setPointerCapture?.(event.pointerId);
-      paintCellInSession(nextSession, dateKey, minutes);
-    },
-    [canEdit, mode, paintCellInSession],
-  );
-
-  const handleCellPointerMove = useCallback(
-    (event: ReactPointerEvent<HTMLButtonElement>, dateKey: string, minutes: number) => {
-      const session = paintSessionRef.current;
-      if (!session || session.pointerId !== event.pointerId) {
-        return;
-      }
-
-      event.preventDefault();
-      continuePaintSession(event.clientX, event.clientY, dateKey, minutes);
-    },
-    [continuePaintSession],
-  );
-
-  const handleCellPointerEnd = useCallback(
-    (event: ReactPointerEvent<HTMLButtonElement>, dateKey: string, minutes: number) => {
-      const session = paintSessionRef.current;
-      if (!session || session.pointerId !== event.pointerId) {
-        return;
-      }
-
-      continuePaintSession(event.clientX, event.clientY, dateKey, minutes);
-
-      if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
-        event.currentTarget.releasePointerCapture?.(event.pointerId);
-      }
-
-      endPaintSession(event.pointerId);
-    },
-    [continuePaintSession, endPaintSession],
-  );
-
-  function toggleParticipantHighlight(participantId: string) {
-    setActiveParticipantId((current) => (current === participantId ? null : participantId));
-  }
-
-  function participantList() {
-    return (
-      <div className="space-y-2">
-        {snapshot.participants.map((participant) => (
-          <button
-            key={participant.id}
-            type="button"
-            aria-pressed={activeParticipantId === participant.id}
-            className={cn(
-              "flex w-full items-center justify-between gap-3 rounded-md border bg-muted/20 px-3 py-2 text-left transition-colors hover:bg-muted/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-              activeParticipantId === participant.id
-                ? "border-foreground/10 bg-background/90 shadow-sm"
-                : "",
-            )}
-            onClick={() => toggleParticipantHighlight(participant.id)}
-          >
-            <div className="flex items-center gap-3">
-              <span
-                className="size-2.5 rounded-full shadow-sm"
-                style={{ background: participant.color }}
-              />
-              <div>
-                <p className="text-sm font-medium text-foreground">
-                  {participant.displayName}
-                  {participant.isCurrentUser ? " (you)" : ""}
-                </p>
-                <p className="text-[11px] text-muted-foreground">
-                  {participant.selectedSlotCount} selected slots
-                </p>
-              </div>
-            </div>
-            {activeParticipantId === participant.id ? (
-              <span className="text-[11px] font-medium text-muted-foreground">Highlighting</span>
+  const sidebarTopContent =
+    snapshot.status === "CLOSED" && snapshot.finalizedSlot ? (
+      <Card>
+        <CardHeader className="p-4 pb-2">
+          <CardTitle className="text-sm">Fixed date</CardTitle>
+          <CardDescription className="text-xs">
+            This event is closed and the organizer picked the final meeting slot.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2 p-4 pt-0">
+          <div className="rounded-md border bg-muted/20 px-3 py-2">
+            <p className="text-sm font-semibold text-foreground">{snapshot.finalizedSlot.label}</p>
+            {snapshot.finalizedSlot.localLabel ? (
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                Your timezone: {snapshot.finalizedSlot.localLabel}
+              </p>
             ) : null}
-          </button>
-        ))}
-      </div>
-    );
-  }
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              {snapshot.finalizedSlot.availableCount} participants free for the full window
+            </p>
+          </div>
+          <Button asChild size="sm" className="w-full">
+            <a href={`/api/events/${slug}/ics`}>Add to calendar (.ics)</a>
+          </Button>
+        </CardContent>
+      </Card>
+    ) : hasAnyAvailability ? (
+      <Card>
+        <CardHeader className="p-4 pb-2">
+          <CardTitle className="text-sm">Best matching windows</CardTitle>
+          <CardDescription className="text-xs">
+            Ranked by overlap across the full {snapshot.meetingDurationMinutes}-minute meeting.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2 p-4 pt-0">
+          {snapshot.suggestions.map((suggestion, index) => (
+            <div key={suggestion.slotStart} className="rounded-md border bg-muted/20 px-3 py-2">
+              <p className="text-[11px] font-medium text-muted-foreground">Option {index + 1}</p>
+              <p className="mt-1 text-sm font-semibold text-foreground">{suggestion.label}</p>
+              {suggestion.localLabel ? (
+                <p className="mt-1 text-[11px] text-muted-foreground">
+                  Your timezone: {suggestion.localLabel}
+                </p>
+              ) : null}
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                {suggestion.availableCount} participants free for the full window
+              </p>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    ) : null;
 
   return (
-    <div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(0,1fr)_250px]">
-      <div className="min-w-0 space-y-4">
-        <Card>
-          <CardHeader className="gap-3 p-4">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-              <div className="space-y-2">
-                <div className="flex flex-wrap items-center gap-2 text-[10px] font-medium tracking-[0.16em] text-muted-foreground uppercase">
-                  <span className="inline-flex items-center gap-1">
-                    <CalendarDaysIcon className="size-3" />
-                    {snapshot.dates.length} days
-                  </span>
-                  <span className="inline-flex items-center gap-1">
-                    <Clock3Icon className="size-3" />
-                    {snapshot.slotMinutes}-minute grid
-                  </span>
-                  <span className="inline-flex items-center gap-1">
-                    <UsersIcon className="size-3" />
-                    {snapshot.participants.length} participants
-                  </span>
-                </div>
-                <div>
-                  <CardTitle className="text-2xl">{snapshot.title}</CardTitle>
-                  <CardDescription className="mt-1 text-xs">
-                    Times shown in <span className="font-medium text-foreground">{snapshot.timezone}</span>
-                  </CardDescription>
-                </div>
-              </div>
-              {snapshot.status === "CLOSED" ? (
-                <Badge variant="destructive" className="h-7 px-2.5 text-xs">
-                  <LockIcon className="size-3.5" />
-                  Closed
-                </Badge>
-              ) : null}
-            </div>
-
-            <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-3">
-              <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
-                <span className="font-medium">Legend</span>
-                <span className="inline-flex items-center gap-1.5">
-                  <span className="size-3 rounded-[3px] border bg-background" />
-                  empty
-                </span>
-                <span className="inline-flex items-center gap-1">
-                  <span className="size-3 rounded-[3px] bg-primary/24" />
-                  some overlap
-                </span>
-                <span className="inline-flex items-center gap-1">
-                  <span className="size-3 rounded-[3px] bg-primary/65" />
-                  high overlap
-                </span>
-                {session && mode === "edit" ? (
-                  <span className="inline-flex items-center gap-1">
-                    <span className="size-3 rounded-[3px] bg-primary/24 outline outline-2 -outline-offset-2 outline-primary/85 ring-1 ring-inset ring-background" />
-                    your availability
-                  </span>
-                ) : null}
-                {activeParticipant ? (
-                  <span className="inline-flex items-center gap-1">
-                    <span
-                      className="size-3 rounded-[3px] border bg-background"
-                      style={getParticipantHighlightStyle({
-                        isHighlighted: true,
-                        participantColor: activeParticipant.color,
-                      })}
-                    />
-                    {activeParticipant.displayName} highlighted
-                  </span>
-                ) : null}
-              </div>
-              <div className="flex items-center gap-2">
-                {session ? (
-                  <Badge variant="secondary" className="h-7 px-2.5 text-xs">
-                    {session.displayName}
-                  </Badge>
-                ) : null}
-                <Sheet>
-                  <SheetTrigger asChild>
-                    <Button variant="outline" size="sm" className="xl:hidden">
-                      Participants
-                    </Button>
-                  </SheetTrigger>
-                  <SheetContent side="bottom" className="max-h-[80vh] rounded-t-xl">
-                    <SheetHeader>
-                      <SheetTitle>Participants</SheetTitle>
-                    </SheetHeader>
-                    <div className="pb-6">{participantList()}</div>
-                  </SheetContent>
-                </Sheet>
-              </div>
-            </div>
-          </CardHeader>
-        </Card>
-
-        {!session ? (
-          <Card>
-            <CardHeader className="p-4 pb-2">
-              <CardTitle className="text-base">Join this board</CardTitle>
-              <CardDescription className="text-xs">
-                Enter your name to start selecting the times that work for you.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="p-4 pt-0">
-              <div className="flex flex-col gap-3 md:flex-row md:items-end">
-                <div className="flex-1 space-y-2">
-                  <Label htmlFor="displayName">Your name</Label>
-                  <Input
-                    id="displayName"
-                    value={name}
-                    onChange={(event) => setName(event.target.value)}
-                    placeholder="Alex, Nora, Product team..."
-                  />
-                </div>
-                <Button onClick={handleJoin} disabled={joining || snapshot.status === "CLOSED"}>
-                  {joining ? <Loader2Icon className="size-4 animate-spin" /> : null}
-                  Join event
-                </Button>
-              </div>
-              {joinError ? <p className="text-sm text-destructive">{joinError}</p> : null}
-            </CardContent>
-          </Card>
-        ) : null}
-
-        <Card className="min-w-0 overflow-hidden">
-          <CardHeader className="flex flex-col gap-3 p-4 pb-2 sm:flex-row sm:items-start sm:justify-between">
-            <div className="space-y-1">
-              <CardTitle className="text-base">Availability</CardTitle>
-              <CardDescription className="text-xs">
-                {mode === "edit"
-                  ? usesDateWindowing
-                    ? "Tap or drag to paint your availability. Use the arrows to move day by day."
-                    : "Click or drag across the grid to paint your availability while keeping the team heatmap in view."
-                  : usesDateWindowing
-                    ? "Select a slot to inspect availability. Use the arrows to move through the date range."
-                    : "Click any slot to see who is available and who is not."}
-              </CardDescription>
-            </div>
-            <div className="inline-flex rounded-md border bg-muted/30 p-1">
-              <Button
-                type="button"
-                size="sm"
-                variant={mode === "edit" ? "secondary" : "ghost"}
-                className="h-7 px-3"
-                aria-pressed={mode === "edit"}
-                disabled={!canEdit}
-                onClick={() => setMode("edit")}
-              >
-                Edit
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant={mode === "view" ? "secondary" : "ghost"}
-                className="h-7 px-3"
-                aria-pressed={mode === "view"}
-                onClick={() => setMode("view")}
-              >
-                View
-              </Button>
-            </div>
-          </CardHeader>
-          <CardContent className="min-w-0 p-4 pt-0">
-            <div className="space-y-3">
-              {usesDateWindowing ? (
-                <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/20 p-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon-xs"
-                    aria-label="Show previous days"
-                    disabled={!canShowPreviousDates}
-                    onClick={() => moveVisibleDateWindow(-1)}
-                  >
-                    <ChevronLeftIcon className="size-4" />
-                  </Button>
-                  <div className="min-w-0 flex-1 text-center">
-                    <p aria-live="polite" className="truncate text-xs font-medium text-foreground">
-                      {visibleRangeLabel}
-                    </p>
-                    <p className="text-[11px] text-muted-foreground">
-                      Days {clampedVisibleDateStartIndex + 1}
-                      {" - "}
-                      {clampedVisibleDateStartIndex + visibleDates.length} of {snapshot.dates.length}
-                    </p>
-                  </div>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon-xs"
-                    aria-label="Show next days"
-                    disabled={!canShowNextDates}
-                    onClick={() => moveVisibleDateWindow(1)}
-                  >
-                    <ChevronRightIcon className="size-4" />
-                  </Button>
-                </div>
-              ) : null}
-
-              <div ref={gridContainerRef} className="min-w-0 overflow-hidden rounded-md border">
-                <div
-                  className={cn(
-                    "grid gap-px bg-border select-none",
-                    mode === "edit" && canEdit ? "touch-none" : "touch-pan-y",
-                  )}
-                  style={{
-                    gridTemplateColumns: `${GRID_TIME_COLUMN_WIDTH_PX}px repeat(${visibleDates.length}, minmax(${GRID_DAY_COLUMN_MIN_WIDTH_PX}px, 1fr))`,
-                  }}
-                >
-                  <div className="sticky left-0 top-0 z-30 bg-background" />
-                  {visibleDates.map((date) => {
-                    const parts = splitDateLabel(date.label);
-
-                    return (
-                      <div
-                        key={date.dateKey}
-                        className="sticky top-0 z-20 flex min-w-[84px] flex-col items-center justify-center bg-background px-2 py-1 text-center"
-                      >
-                        <span className="text-[11px] font-semibold leading-none text-foreground">
-                          {parts.weekday}
-                        </span>
-                        <span className="mt-0.5 text-[10px] leading-none text-muted-foreground">
-                          {parts.monthDay}
-                        </span>
-                      </div>
-                    );
-                  })}
-                  {snapshot.timeRows.map((timeRow) => (
-                    <Fragment key={timeRow.minutes}>
-                      <div
-                        className={cn(
-                          "sticky left-0 z-10 flex items-center justify-end bg-background px-2 text-[11px] font-medium text-muted-foreground",
-                          cellHeightClass,
-                        )}
-                      >
-                        {isMajorTimeLabel(timeRow.minutes) ? timeRow.label : ""}
-                      </div>
-                      {visibleDates.map((date) => {
-                        const key = slotKey(date.dateKey, timeRow.minutes);
-                        const slot = slotMap.get(key);
-                        if (!slot) {
-                          return null;
-                        }
-
-                        const availableNames = slot.participantIds
-                          .map((participantId) => participantNamesById.get(participantId))
-                          .filter(Boolean) as string[];
-                        const availabilityTitle = availableNames.length
-                          ? `${date.label} ${timeRow.label} · ${slot.availabilityCount}/${snapshot.participants.length} available · ${availableNames.join(", ")}`
-                          : `${date.label} ${timeRow.label} · nobody available`;
-
-                        const isActiveViewSlot = mode === "view" && activeSlotKey === key;
-                        const showCurrentUserSelection =
-                          mode === "edit" && slot.selectedByCurrentUser;
-                        const isHighlightedParticipantAvailable = activeParticipantId
-                          ? slot.participantIds.includes(activeParticipantId)
-                          : false;
-
-                        return (
-                          <button
-                            key={key}
-                            type="button"
-                            aria-label={availabilityTitle}
-                            aria-pressed={mode === "edit" ? slot.selectedByCurrentUser : isActiveViewSlot}
-                            title={availabilityTitle}
-                            data-slot-key={key}
-                            data-date-key={date.dateKey}
-                            data-minutes={timeRow.minutes}
-                            data-current-user-selected={
-                              showCurrentUserSelection ? "true" : undefined
-                            }
-                            data-highlighted-participant-availability={
-                              isHighlightedParticipantAvailable ? "true" : undefined
-                            }
-                            className={cn(
-                              "min-w-[84px] border-0 transition-colors focus-visible:relative focus-visible:z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
-                              cellHeightClass,
-                              mode === "edit" && canEdit
-                                ? "cursor-crosshair touch-none hover:brightness-[0.98]"
-                                : "cursor-pointer hover:brightness-[0.99]",
-                              getHeatColor(slot.availabilityCount),
-                              getCurrentUserSelectionClass(showCurrentUserSelection),
-                              getActiveViewSelectionClass(isActiveViewSlot),
-                            )}
-                            style={getParticipantHighlightStyle({
-                              isHighlighted: isHighlightedParticipantAvailable,
-                              participantColor: activeParticipantId
-                                ? participantColorById.get(activeParticipantId)
-                                : undefined,
-                            })}
-                            onPointerDown={(event) =>
-                              handleCellPointerDown(
-                                event,
-                                date.dateKey,
-                                timeRow.minutes,
-                                slot.selectedByCurrentUser,
-                              )
-                            }
-                            onPointerMove={(event) =>
-                              handleCellPointerMove(event, date.dateKey, timeRow.minutes)
-                            }
-                            onPointerUp={(event) =>
-                              handleCellPointerEnd(event, date.dateKey, timeRow.minutes)
-                            }
-                            onPointerCancel={(event) =>
-                              handleCellPointerEnd(event, date.dateKey, timeRow.minutes)
-                            }
-                            onLostPointerCapture={(event) => {
-                              endPaintSession(event.pointerId);
-                            }}
-                            onClick={() => {
-                              if (mode !== "view") {
-                                return;
-                              }
-
-                              setActiveSlotKey(key);
-                            }}
-                          >
-                            <span className="sr-only">{availabilityTitle}</span>
-                          </button>
-                        );
-                      })}
-                    </Fragment>
-                  ))}
-                </div>
-              </div>
-            </div>
-            {mode === "view" ? (
-              <div className="mt-4 rounded-md border bg-muted/10 p-4">
-                <div className="space-y-1">
-                  <h3 className="text-sm font-semibold text-foreground">Slot details</h3>
-                  {activeSlotDetails ? (
-                    <p className="text-xs text-muted-foreground">
-                      {activeSlotDetails.dateLabel} · {activeSlotDetails.timeLabel} ·{" "}
-                      {activeSlotDetails.slot.availabilityCount}/{snapshot.participants.length} available
-                    </p>
-                  ) : (
-                    <p className="text-xs text-muted-foreground">
-                      Select a slot in the heatmap to inspect availability for that time.
-                    </p>
-                  )}
-                </div>
-
-                {activeSlotDetails ? (
-                  <div className="mt-4 grid gap-4 lg:grid-cols-2">
-                    <div className="space-y-2">
-                      <h4 className="text-xs font-medium tracking-[0.14em] text-muted-foreground uppercase">
-                        Available
-                      </h4>
-                      {activeSlotDetails.availableParticipants.length ? (
-                        <div className="space-y-2">
-                          {activeSlotDetails.availableParticipants.map((participant) => (
-                            <div
-                              key={participant.id}
-                              className="flex items-center gap-3 rounded-md border bg-background/80 px-3 py-2"
-                            >
-                              <span
-                                className="size-2.5 rounded-full shadow-sm"
-                                style={{ background: participant.color }}
-                              />
-                              <span className="text-sm font-medium text-foreground">
-                                {participant.displayName}
-                                {participant.isCurrentUser ? " (you)" : ""}
-                              </span>
-                            </div>
-                          ))}
-                        </div>
-                      ) : (
-                        <p className="text-sm text-muted-foreground">Nobody is available in this slot.</p>
-                      )}
-                    </div>
-                    <div className="space-y-2">
-                      <h4 className="text-xs font-medium tracking-[0.14em] text-muted-foreground uppercase">
-                        Not available
-                      </h4>
-                      {activeSlotDetails.unavailableParticipants.length ? (
-                        <div className="space-y-2">
-                          {activeSlotDetails.unavailableParticipants.map((participant) => (
-                            <div
-                              key={participant.id}
-                              className="flex items-center gap-3 rounded-md border border-dashed bg-background/60 px-3 py-2"
-                            >
-                              <span
-                                className="size-2.5 rounded-full opacity-65 shadow-sm"
-                                style={{ background: participant.color }}
-                              />
-                              <span className="text-sm font-medium text-foreground">
-                                {participant.displayName}
-                                {participant.isCurrentUser ? " (you)" : ""}
-                              </span>
-                            </div>
-                          ))}
-                        </div>
-                      ) : (
-                        <p className="text-sm text-muted-foreground">
-                          Everyone with at least one selection is available here.
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-            ) : null}
-          </CardContent>
-        </Card>
-      </div>
-
-      <aside className="hidden min-w-0 space-y-4 xl:block">
-        {hasAnyAvailability ? (
-          <Card>
-            <CardHeader className="p-4 pb-2">
-              <CardTitle className="text-sm">Best matching windows</CardTitle>
-              <CardDescription className="text-xs">
-                Ranked by overlap across the full {snapshot.meetingDurationMinutes}-minute meeting.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-2 p-4 pt-0">
-              {snapshot.suggestions.map((suggestion, index) => (
-                <div
-                  key={suggestion.slotStart}
-                  className="rounded-md border bg-muted/20 px-3 py-2"
-                >
-                  <p className="text-[11px] font-medium text-muted-foreground">
-                    Option {index + 1}
-                  </p>
-                  <p className="mt-1 text-sm font-semibold text-foreground">{suggestion.label}</p>
-                  {suggestion.localLabel ? (
-                    <p className="mt-1 text-[11px] text-muted-foreground">
-                      Your timezone: {suggestion.localLabel}
-                    </p>
-                  ) : null}
-                  <p className="mt-1 text-[11px] text-muted-foreground">
-                    {suggestion.availableCount} participants free for the full window
-                  </p>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-        ) : null}
-
+    <div className="space-y-4">
+      {!session ? (
         <Card>
           <CardHeader className="p-4 pb-2">
-            <CardTitle className="text-sm">Participants</CardTitle>
+            <CardTitle className="text-base">Join this board</CardTitle>
             <CardDescription className="text-xs">
-              Click a participant to highlight their availability on the grid.
+              Enter your name to start selecting the times that work for you.
             </CardDescription>
           </CardHeader>
-          <CardContent className="p-4 pt-0">{participantList()}</CardContent>
+          <CardContent className="p-4 pt-0">
+            <div className="flex flex-col gap-3 md:flex-row md:items-end">
+              <div className="flex-1 space-y-2">
+                <Label htmlFor="displayName">Your name</Label>
+                <Input
+                  id="displayName"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  placeholder="Alex, Nora, Product team..."
+                />
+              </div>
+              <Button onClick={handleJoin} disabled={joining || snapshot.status === "CLOSED"}>
+                {joining ? <Loader2Icon className="size-4 animate-spin" /> : null}
+                Join event
+              </Button>
+            </div>
+            {joinError ? <p className="text-sm text-destructive">{joinError}</p> : null}
+          </CardContent>
         </Card>
-      </aside>
+      ) : null}
+
+      <EventHeatmap
+        snapshot={snapshot}
+        mode={mode}
+        onModeChange={setMode}
+        canEdit={canEdit}
+        selectedMap={selectedMap}
+        onUpdateCell={updateCell}
+        finalSlotStart={snapshot.finalizedSlot?.slotStart ?? null}
+        sessionBadgeLabel={session?.displayName ?? null}
+        sidebarTopContent={sidebarTopContent}
+      />
     </div>
   );
 }

--- a/src/lib/availability.test.ts
+++ b/src/lib/availability.test.ts
@@ -21,6 +21,7 @@ describe("availability helpers", () => {
       dayStartMinutes: 9 * 60,
       dayEndMinutes: 12 * 60,
       dates: ["2026-04-10"],
+      finalSlotStart: null,
       participants: [
         {
           id: "p1",
@@ -58,5 +59,73 @@ describe("availability helpers", () => {
     expect(snapshot.suggestions[0]?.slotStart).toBe(
       buildSlotStart("2026-04-10", 9 * 60, "Europe/Vienna"),
     );
+    expect(snapshot.finalizedSlot).toBeNull();
+  });
+
+  it("builds a finalized slot from the stored start and clears invalid starts", () => {
+    const validSlotStart = buildSlotStart("2026-04-10", 9 * 60, "Europe/Vienna");
+
+    const snapshot = buildSnapshot({
+      id: "event_1",
+      slug: "design-review",
+      title: "Design Review",
+      timezone: "Europe/Vienna",
+      status: "CLOSED",
+      slotMinutes: 30,
+      meetingDurationMinutes: 60,
+      dayStartMinutes: 9 * 60,
+      dayEndMinutes: 11 * 60,
+      dates: ["2026-04-10"],
+      finalSlotStart: validSlotStart,
+      participants: [
+        {
+          id: "p1",
+          displayName: "Alice",
+          color: "red",
+          availabilitySlotStarts: [
+            validSlotStart,
+            buildSlotStart("2026-04-10", 9 * 60 + 30, "Europe/Vienna"),
+          ],
+        },
+        {
+          id: "p2",
+          displayName: "Bob",
+          color: "blue",
+          availabilitySlotStarts: [
+            validSlotStart,
+            buildSlotStart("2026-04-10", 9 * 60 + 30, "Europe/Vienna"),
+          ],
+        },
+      ],
+    });
+
+    expect(snapshot.finalizedSlot).toMatchObject({
+      slotStart: validSlotStart,
+      availableCount: 2,
+    });
+
+    const invalidSnapshot = buildSnapshot({
+      id: "event_1",
+      slug: "design-review",
+      title: "Design Review",
+      timezone: "Europe/Vienna",
+      status: "CLOSED",
+      slotMinutes: 30,
+      meetingDurationMinutes: 60,
+      dayStartMinutes: 9 * 60,
+      dayEndMinutes: 11 * 60,
+      dates: ["2026-04-10"],
+      finalSlotStart: buildSlotStart("2026-04-10", 10 * 60 + 30, "Europe/Vienna"),
+      participants: [
+        {
+          id: "p1",
+          displayName: "Alice",
+          color: "red",
+          availabilitySlotStarts: [validSlotStart],
+        },
+      ],
+    });
+
+    expect(invalidSnapshot.finalizedSlot).toBeNull();
   });
 });

--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -2,6 +2,7 @@ import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 
 import type {
   BestTimeSuggestion,
+  FinalizedEventSlot,
   PublicEventSnapshot,
   SnapshotDate,
   SnapshotParticipant,
@@ -26,9 +27,27 @@ type BuildSnapshotInput = {
     color: string;
     availabilitySlotStarts: string[];
   }>;
+  finalSlotStart?: string | null;
   currentParticipantId?: string | null;
   viewerTimezone?: string | null;
 };
+
+type MeetingWindow = {
+  dateKey: string;
+  slotStart: string;
+  slotEnd: string;
+  slotStarts: string[];
+};
+
+type MeetingWindowSummary = FinalizedEventSlot & {
+  sumCount: number;
+};
+
+function isMeetingWindowSummary(
+  value: MeetingWindowSummary | null,
+): value is MeetingWindowSummary {
+  return value !== null;
+}
 
 function pad(value: number) {
   return String(value).padStart(2, "0");
@@ -57,10 +76,7 @@ export function sortDateKeys(dateKeys: string[]) {
 export function buildSlotStart(dateKey: string, minutes: number, timezone: string) {
   const hours = Math.floor(minutes / 60);
   const mins = minutes % 60;
-  return fromZonedTime(
-    `${dateKey}T${pad(hours)}:${pad(mins)}:00`,
-    timezone,
-  ).toISOString();
+  return fromZonedTime(`${dateKey}T${pad(hours)}:${pad(mins)}:00`, timezone).toISOString();
 }
 
 export function formatDateKeyLabel(dateKey: string, timezone: string) {
@@ -79,6 +95,210 @@ export function getViewerTimezone() {
   }
 }
 
+export function buildTimeRows({
+  slotMinutes,
+  dayStartMinutes,
+  dayEndMinutes,
+}: {
+  slotMinutes: number;
+  dayStartMinutes: number;
+  dayEndMinutes: number;
+}) {
+  const timeRows: SnapshotTimeRow[] = [];
+
+  for (let minutes = dayStartMinutes; minutes < dayEndMinutes; minutes += slotMinutes) {
+    timeRows.push({
+      minutes,
+      label: minutesToLabel(minutes),
+    });
+  }
+
+  return timeRows;
+}
+
+function getMeetingWindowSize(slotMinutes: number, meetingDurationMinutes: number) {
+  return Math.max(1, Math.floor(meetingDurationMinutes / slotMinutes));
+}
+
+export function buildMeetingWindows({
+  dates,
+  timezone,
+  dayStartMinutes,
+  dayEndMinutes,
+  slotMinutes,
+  meetingDurationMinutes,
+}: {
+  dates: string[];
+  timezone: string;
+  dayStartMinutes: number;
+  dayEndMinutes: number;
+  slotMinutes: number;
+  meetingDurationMinutes: number;
+}) {
+  const meetingWindows: MeetingWindow[] = [];
+  const timeRows = buildTimeRows({
+    slotMinutes,
+    dayStartMinutes,
+    dayEndMinutes,
+  });
+  const windowSize = getMeetingWindowSize(slotMinutes, meetingDurationMinutes);
+
+  for (const dateKey of sortDateKeys(dates)) {
+    for (let index = 0; index <= timeRows.length - windowSize; index += 1) {
+      const windowRows = timeRows.slice(index, index + windowSize);
+      const slotStarts = windowRows.map((timeRow) => buildSlotStart(dateKey, timeRow.minutes, timezone));
+      const slotStart = slotStarts[0];
+
+      if (!slotStart) {
+        continue;
+      }
+
+      const slotEnd = new Date(
+        new Date(slotStarts[slotStarts.length - 1]).getTime() + slotMinutes * 60 * 1000,
+      ).toISOString();
+
+      meetingWindows.push({
+        dateKey,
+        slotStart,
+        slotEnd,
+        slotStarts,
+      });
+    }
+  }
+
+  return meetingWindows;
+}
+
+function getMeetingWindowLabels({
+  slotStart,
+  slotEnd,
+  timezone,
+  viewerTimezone,
+}: {
+  slotStart: string;
+  slotEnd: string;
+  timezone: string;
+  viewerTimezone?: string | null;
+}) {
+  const start = new Date(slotStart);
+  const end = new Date(slotEnd);
+
+  return {
+    label: `${formatInTimeZone(start, timezone, "EEE, MMM d · HH:mm")}–${formatInTimeZone(
+      end,
+      timezone,
+      "HH:mm",
+    )}`,
+    localLabel:
+      viewerTimezone && viewerTimezone !== timezone
+        ? `${formatInTimeZone(start, viewerTimezone, "EEE, MMM d · HH:mm")}–${formatInTimeZone(
+            end,
+            viewerTimezone,
+            "HH:mm",
+          )}`
+        : null,
+  };
+}
+
+function summarizeMeetingWindow({
+  meetingWindow,
+  slotMap,
+  timezone,
+  viewerTimezone,
+}: {
+  meetingWindow: MeetingWindow;
+  slotMap: Map<string, SnapshotSlot>;
+  timezone: string;
+  viewerTimezone?: string | null;
+}): MeetingWindowSummary | null {
+  const windowSlots = meetingWindow.slotStarts
+    .map((slotStart) => slotMap.get(slotStart))
+    .filter(Boolean) as SnapshotSlot[];
+
+  if (windowSlots.length !== meetingWindow.slotStarts.length) {
+    return null;
+  }
+
+  const participantIdSets = windowSlots.map((slot) => new Set(slot.participantIds));
+  const participantIds = participantIdSets.length
+    ? [...participantIdSets[0]].filter((participantId) =>
+        participantIdSets.every((set) => set.has(participantId)),
+      )
+    : [];
+  const availableCount = windowSlots.length
+    ? Math.min(...windowSlots.map((slot) => slot.availabilityCount))
+    : 0;
+  const sumCount = windowSlots.reduce((acc, slot) => acc + slot.availabilityCount, 0);
+  const labels = getMeetingWindowLabels({
+    slotStart: meetingWindow.slotStart,
+    slotEnd: meetingWindow.slotEnd,
+    timezone,
+    viewerTimezone,
+  });
+
+  return {
+    slotStart: meetingWindow.slotStart,
+    slotEnd: meetingWindow.slotEnd,
+    dateKey: meetingWindow.dateKey,
+    label: labels.label,
+    localLabel: labels.localLabel,
+    availableCount,
+    participantIds,
+    sumCount,
+  };
+}
+
+export function buildFinalizedSlot({
+  dates,
+  timezone,
+  dayStartMinutes,
+  dayEndMinutes,
+  slotMinutes,
+  meetingDurationMinutes,
+  slots,
+  finalSlotStart,
+  viewerTimezone,
+}: {
+  dates: string[];
+  timezone: string;
+  dayStartMinutes: number;
+  dayEndMinutes: number;
+  slotMinutes: number;
+  meetingDurationMinutes: number;
+  slots: SnapshotSlot[];
+  finalSlotStart: string;
+  viewerTimezone?: string | null;
+}): FinalizedEventSlot | null {
+  const meetingWindow = buildMeetingWindows({
+    dates,
+    timezone,
+    dayStartMinutes,
+    dayEndMinutes,
+    slotMinutes,
+    meetingDurationMinutes,
+  }).find((candidate) => candidate.slotStart === finalSlotStart);
+
+  if (!meetingWindow) {
+    return null;
+  }
+
+  const slotMap = new Map(slots.map((slot) => [slot.slotStart, slot]));
+
+  const summary = summarizeMeetingWindow({
+    meetingWindow,
+    slotMap,
+    timezone,
+    viewerTimezone,
+  });
+
+  if (!summary) {
+    return null;
+  }
+
+  const { sumCount: _sumCount, ...finalizedSlot } = summary;
+  return finalizedSlot;
+}
+
 export function buildSnapshot({
   id,
   slug,
@@ -91,6 +311,7 @@ export function buildSnapshot({
   dayEndMinutes,
   dates,
   participants,
+  finalSlotStart,
   currentParticipantId,
   viewerTimezone,
 }: BuildSnapshotInput): PublicEventSnapshot {
@@ -99,14 +320,11 @@ export function buildSnapshot({
     dateKey,
     label: formatDateKeyLabel(dateKey, timezone),
   }));
-
-  const timeRows: SnapshotTimeRow[] = [];
-  for (let minutes = dayStartMinutes; minutes < dayEndMinutes; minutes += slotMinutes) {
-    timeRows.push({
-      minutes,
-      label: minutesToLabel(minutes),
-    });
-  }
+  const timeRows = buildTimeRows({
+    slotMinutes,
+    dayStartMinutes,
+    dayEndMinutes,
+  });
 
   const participantSelections = new Map<string, Set<string>>();
   const slotParticipants = new Map<string, Set<string>>();
@@ -151,14 +369,30 @@ export function buildSnapshot({
   }));
 
   const suggestions = rankBestSuggestions({
+    dates: sortedDates,
+    timezone,
+    dayStartMinutes,
+    dayEndMinutes,
     slotMinutes,
     meetingDurationMinutes,
-    timezone,
-    viewerTimezone,
-    timeRows,
-    dates: sortedDates,
     slots,
+    viewerTimezone,
   });
+
+  const finalizedSlot =
+    finalSlotStart && status === "CLOSED"
+      ? buildFinalizedSlot({
+          dates: sortedDates,
+          timezone,
+          dayStartMinutes,
+          dayEndMinutes,
+          slotMinutes,
+          meetingDurationMinutes,
+          slots,
+          finalSlotStart,
+          viewerTimezone,
+        })
+      : null;
 
   const currentParticipant =
     participantEntries.find((participant) => participant.isCurrentUser) ?? null;
@@ -178,92 +412,53 @@ export function buildSnapshot({
     slots,
     participants: participantEntries,
     suggestions,
+    finalizedSlot,
     currentParticipant,
   };
 }
 
 function rankBestSuggestions({
+  dates,
+  timezone,
+  dayStartMinutes,
+  dayEndMinutes,
   slotMinutes,
   meetingDurationMinutes,
-  timezone,
-  viewerTimezone,
-  timeRows,
-  dates,
   slots,
+  viewerTimezone,
 }: {
+  dates: string[];
+  timezone: string;
+  dayStartMinutes: number;
+  dayEndMinutes: number;
   slotMinutes: number;
   meetingDurationMinutes: number;
-  timezone: string;
-  viewerTimezone?: string | null;
-  timeRows: SnapshotTimeRow[];
-  dates: string[];
   slots: SnapshotSlot[];
+  viewerTimezone?: string | null;
 }): BestTimeSuggestion[] {
-  const windowSize = Math.max(1, Math.floor(meetingDurationMinutes / slotMinutes));
-  const slotMap = new Map<string, SnapshotSlot>();
+  const meetingWindows = buildMeetingWindows({
+    dates,
+    timezone,
+    dayStartMinutes,
+    dayEndMinutes,
+    slotMinutes,
+    meetingDurationMinutes,
+  });
+  const slotMap = new Map(slots.map((slot) => [slot.slotStart, slot]));
 
-  for (const slot of slots) {
-    slotMap.set(`${slot.dateKey}-${slot.minutes}`, slot);
-  }
-
-  const ranked: Array<BestTimeSuggestion & { minCount: number; sumCount: number }> = [];
-
-  for (const dateKey of dates) {
-    for (let index = 0; index <= timeRows.length - windowSize; index += 1) {
-      const windowRows = timeRows.slice(index, index + windowSize);
-      const windowSlots = windowRows
-        .map((row) => slotMap.get(`${dateKey}-${row.minutes}`))
-        .filter(Boolean) as SnapshotSlot[];
-
-      if (windowSlots.length !== windowSize) {
-        continue;
-      }
-
-      const participantIdSets = windowSlots.map((slot) => new Set(slot.participantIds));
-      const overlapIds = [...participantIdSets[0]].filter((participantId) =>
-        participantIdSets.every((set) => set.has(participantId)),
-      );
-
-      const minCount = Math.min(...windowSlots.map((slot) => slot.availabilityCount));
-      const sumCount = windowSlots.reduce((acc, slot) => acc + slot.availabilityCount, 0);
-      const start = windowSlots[0].slotStart;
-      const end = new Date(
-        new Date(windowSlots[windowSlots.length - 1].slotStart).getTime() +
-          slotMinutes * 60 * 1000,
-      );
-
-      const label = `${formatInTimeZone(new Date(start), timezone, "EEE, MMM d · HH:mm")}–${formatInTimeZone(
-        end,
+  return meetingWindows
+    .map((meetingWindow) =>
+      summarizeMeetingWindow({
+        meetingWindow,
+        slotMap,
         timezone,
-        "HH:mm",
-      )}`;
-      const localLabel =
-        viewerTimezone && viewerTimezone !== timezone
-          ? `${formatInTimeZone(new Date(start), viewerTimezone, "EEE, MMM d · HH:mm")}–${formatInTimeZone(
-              end,
-              viewerTimezone,
-              "HH:mm",
-            )}`
-          : null;
-
-      ranked.push({
-        slotStart: start,
-        slotEnd: end.toISOString(),
-        dateKey,
-        label,
-        localLabel,
-        availableCount: minCount,
-        participantIds: overlapIds,
-        minCount,
-        sumCount,
-      });
-    }
-  }
-
-  return ranked
+        viewerTimezone,
+      }),
+    )
+    .filter(isMeetingWindowSummary)
     .sort((left, right) => {
-      if (right.minCount !== left.minCount) {
-        return right.minCount - left.minCount;
+      if (right.availableCount !== left.availableCount) {
+        return right.availableCount - left.availableCount;
       }
 
       if (right.sumCount !== left.sumCount) {
@@ -273,15 +468,7 @@ function rankBestSuggestions({
       return left.slotStart.localeCompare(right.slotStart);
     })
     .slice(0, 3)
-    .map((suggestion) => ({
-      slotStart: suggestion.slotStart,
-      slotEnd: suggestion.slotEnd,
-      dateKey: suggestion.dateKey,
-      label: suggestion.label,
-      localLabel: suggestion.localLabel,
-      availableCount: suggestion.availableCount,
-      participantIds: suggestion.participantIds,
-    }));
+    .map(({ sumCount: _sumCount, ...suggestion }) => suggestion);
 }
 
 export function getAllowedSlotStarts({
@@ -298,12 +485,44 @@ export function getAllowedSlotStarts({
   slotMinutes: number;
 }) {
   const allowed = new Set<string>();
+  const timeRows = buildTimeRows({
+    slotMinutes,
+    dayStartMinutes,
+    dayEndMinutes,
+  });
 
   for (const dateKey of dates) {
-    for (let minutes = dayStartMinutes; minutes < dayEndMinutes; minutes += slotMinutes) {
-      allowed.add(buildSlotStart(dateKey, minutes, timezone));
+    for (const timeRow of timeRows) {
+      allowed.add(buildSlotStart(dateKey, timeRow.minutes, timezone));
     }
   }
 
   return allowed;
+}
+
+export function getAllowedFinalSlotStarts({
+  dates,
+  timezone,
+  dayStartMinutes,
+  dayEndMinutes,
+  slotMinutes,
+  meetingDurationMinutes,
+}: {
+  dates: string[];
+  timezone: string;
+  dayStartMinutes: number;
+  dayEndMinutes: number;
+  slotMinutes: number;
+  meetingDurationMinutes: number;
+}) {
+  return new Set(
+    buildMeetingWindows({
+      dates,
+      timezone,
+      dayStartMinutes,
+      dayEndMinutes,
+      slotMinutes,
+      meetingDurationMinutes,
+    }).map((meetingWindow) => meetingWindow.slotStart),
+  );
 }

--- a/src/lib/event-service.test.ts
+++ b/src/lib/event-service.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildSlotStart } from "@/lib/availability";
+import { hashSecret } from "@/lib/tokens";
+
+const prisma = {
+  event: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+  participant: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+};
+
+const publishEventUpdate = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma,
+}));
+
+vi.mock("@/lib/realtime", () => ({
+  publishEventUpdate,
+}));
+
+function createManagedEvent() {
+  return {
+    id: "event_1",
+    slug: "team-sync",
+    title: "Team Sync",
+    timezone: "Europe/Vienna",
+    slotMinutes: 30,
+    meetingDurationMinutes: 60,
+    dayStartMinutes: 9 * 60,
+    dayEndMinutes: 11 * 60,
+    status: "OPEN" as const,
+    finalSlotStartAt: null,
+    manageTokenHash: hashSecret("secret"),
+    createdAt: new Date("2026-03-28T10:00:00.000Z"),
+    updatedAt: new Date("2026-03-28T10:00:00.000Z"),
+    dates: [
+      {
+        id: "date_1",
+        eventId: "event_1",
+        dateKey: "2026-04-02",
+        createdAt: new Date("2026-03-28T10:00:00.000Z"),
+      },
+    ],
+    participants: [],
+  };
+}
+
+describe("updateManagedEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    prisma.event.findUnique.mockResolvedValue(createManagedEvent());
+    prisma.event.update.mockResolvedValue(undefined);
+    publishEventUpdate.mockResolvedValue(undefined);
+  });
+
+  it("requires a fixed date before closing an event", async () => {
+    const { updateManagedEvent } = await import("./event-service");
+
+    await expect(
+      updateManagedEvent("event_1.secret", {
+        action: "updateEvent",
+        title: "Closed title",
+        status: "CLOSED",
+        finalSlotStart: null,
+      }),
+    ).rejects.toMatchObject({
+      code: "final_slot_required",
+    });
+
+    expect(prisma.event.update).not.toHaveBeenCalled();
+  });
+
+  it("stores a valid fixed date when closing an event", async () => {
+    const { updateManagedEvent } = await import("./event-service");
+    const finalSlotStart = buildSlotStart("2026-04-02", 9 * 60, "Europe/Vienna");
+
+    await updateManagedEvent("event_1.secret", {
+      action: "updateEvent",
+      title: "Closed title",
+      status: "CLOSED",
+      finalSlotStart,
+    });
+
+    expect(prisma.event.update).toHaveBeenCalledWith({
+      where: {
+        id: "event_1",
+      },
+      data: {
+        title: "Closed title",
+        status: "CLOSED",
+        finalSlotStartAt: new Date(finalSlotStart),
+      },
+    });
+  });
+
+  it("clears the fixed date when reopening an event", async () => {
+    const { updateManagedEvent } = await import("./event-service");
+    const finalSlotStart = buildSlotStart("2026-04-02", 9 * 60, "Europe/Vienna");
+
+    await updateManagedEvent("event_1.secret", {
+      action: "updateEvent",
+      title: "Open title",
+      status: "OPEN",
+      finalSlotStart,
+    });
+
+    expect(prisma.event.update).toHaveBeenCalledWith({
+      where: {
+        id: "event_1",
+      },
+      data: {
+        title: "Open title",
+        status: "OPEN",
+        finalSlotStartAt: null,
+      },
+    });
+  });
+});

--- a/src/lib/event-service.ts
+++ b/src/lib/event-service.ts
@@ -2,7 +2,11 @@ import { Prisma } from "@prisma/client";
 
 import { appConfig } from "@/lib/config";
 import { prisma } from "@/lib/prisma";
-import { buildSnapshot, getAllowedSlotStarts } from "@/lib/availability";
+import {
+  buildSnapshot,
+  getAllowedFinalSlotStarts,
+  getAllowedSlotStarts,
+} from "@/lib/availability";
 import {
   buildManageKey,
   buildManageUrl,
@@ -122,6 +126,7 @@ function toSnapshot(
       color: participant.color,
       availabilitySlotStarts: participant.availabilitySlots.map((slot) => slot.slotStartAt.toISOString()),
     })),
+    finalSlotStart: event.finalSlotStartAt?.toISOString() ?? null,
     currentParticipantId,
   });
 }
@@ -444,6 +449,7 @@ export async function updateManagedEvent(
         action: "updateEvent";
         title: string;
         status: "OPEN" | "CLOSED";
+        finalSlotStart: string | null;
       }
     | {
         action: "renameParticipant";
@@ -454,6 +460,35 @@ export async function updateManagedEvent(
   const event = await verifyManageKey(manageKey);
 
   if (input.action === "updateEvent") {
+    let finalSlotStartAt: Date | null = null;
+
+    if (input.status === "CLOSED") {
+      if (!input.finalSlotStart) {
+        throw conflict(
+          "Pick a fixed date before closing this event.",
+          "final_slot_required",
+        );
+      }
+
+      const allowedFinalSlotStarts = getAllowedFinalSlotStarts({
+        dates: event.dates.map((date) => date.dateKey),
+        timezone: event.timezone,
+        dayStartMinutes: event.dayStartMinutes,
+        dayEndMinutes: event.dayEndMinutes,
+        slotMinutes: event.slotMinutes,
+        meetingDurationMinutes: event.meetingDurationMinutes,
+      });
+
+      if (!allowedFinalSlotStarts.has(input.finalSlotStart)) {
+        throw conflict(
+          "Pick a valid fixed date that fits the full meeting duration.",
+          "final_slot_invalid",
+        );
+      }
+
+      finalSlotStartAt = new Date(input.finalSlotStart);
+    }
+
     await prisma.event.update({
       where: {
         id: event.id,
@@ -461,6 +496,7 @@ export async function updateManagedEvent(
       data: {
         title: input.title,
         status: input.status,
+        finalSlotStartAt,
       },
     });
   }

--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -1,0 +1,57 @@
+import { formatInTimeZone } from "date-fns-tz";
+
+function escapeIcsText(value: string) {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\r?\n/g, "\\n")
+    .replace(/,/g, "\\,")
+    .replace(/;/g, "\\;");
+}
+
+function formatIcsTimestamp(date: Date) {
+  return formatInTimeZone(date, "UTC", "yyyyMMdd'T'HHmmss'Z'");
+}
+
+function formatIcsZonedDateTime(date: Date, timezone: string) {
+  return formatInTimeZone(date, timezone, "yyyyMMdd'T'HHmmss");
+}
+
+export function buildEventCalendarFile({
+  slug,
+  title,
+  timezone,
+  slotStart,
+  slotEnd,
+  url,
+  generatedAt = new Date(),
+}: {
+  slug: string;
+  title: string;
+  timezone: string;
+  slotStart: string;
+  slotEnd: string;
+  url: string;
+  generatedAt?: Date;
+}) {
+  const uid = `${slug}-${slotStart}@tempoll`;
+  const description = `Scheduled with tempoll: ${url}`;
+
+  return [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//tempoll//Event Calendar//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    "BEGIN:VEVENT",
+    `UID:${escapeIcsText(uid)}`,
+    `DTSTAMP:${formatIcsTimestamp(generatedAt)}`,
+    `DTSTART;TZID=${timezone}:${formatIcsZonedDateTime(new Date(slotStart), timezone)}`,
+    `DTEND;TZID=${timezone}:${formatIcsZonedDateTime(new Date(slotEnd), timezone)}`,
+    `SUMMARY:${escapeIcsText(title)}`,
+    `DESCRIPTION:${escapeIcsText(description)}`,
+    `URL:${escapeIcsText(url)}`,
+    "END:VEVENT",
+    "END:VCALENDAR",
+    "",
+  ].join("\r\n");
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -55,6 +55,16 @@ export type BestTimeSuggestion = {
   participantIds: string[];
 };
 
+export type FinalizedEventSlot = {
+  slotStart: string;
+  slotEnd: string;
+  dateKey: string;
+  label: string;
+  localLabel: string | null;
+  availableCount: number;
+  participantIds: string[];
+};
+
 export type PublicEventSnapshot = {
   id: string;
   slug: string;
@@ -70,6 +80,7 @@ export type PublicEventSnapshot = {
   slots: SnapshotSlot[];
   participants: SnapshotParticipant[];
   suggestions: BestTimeSuggestion[];
+  finalizedSlot: FinalizedEventSlot | null;
   currentParticipant: SnapshotParticipant | null;
 };
 

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -68,6 +68,7 @@ export const manageUpdateSchema = z.discriminatedUnion("action", [
     action: z.literal("updateEvent"),
     title: z.string().trim().min(3).max(80),
     status: z.enum(["OPEN", "CLOSED"]),
+    finalSlotStart: z.string().datetime().nullable(),
   }),
   z.object({
     action: z.literal("renameParticipant"),


### PR DESCRIPTION
## Summary
- add persisted final meeting slots for closed events, including validation and snapshot support
- refactor the heatmap into a shared component used by both public and organizer views
- let organizers select and preview a fixed date from the manage view, with reopening clearing the selection
- show the fixed date on the public page, mark it across the heatmap, and add `.ics` calendar export support
- add coverage for availability helpers, organizer updates, public/manage UI, and the new ICS route

## Testing
- `pnpm prisma generate`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:run`