### PR TITLE
Fix browser titles to always include tempoll.app

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,6 +24,7 @@ const headingFont = Space_Grotesk({
 });
 
 const defaultLogoSrc = "/tempoll-logo.png";
+const browserTitleBrand = "tempoll.app";
 const hasDefaultLogo = existsSync(
   path.join(process.cwd(), "public", "tempoll-logo.png"),
 );
@@ -33,8 +34,8 @@ export async function generateMetadata(): Promise<Metadata> {
 
   return {
     title: {
-      default: appConfig.appName,
-      template: `%s · ${appConfig.appName}`,
+      default: browserTitleBrand,
+      template: `%s · ${browserTitleBrand}`,
     },
     description: messages.metadata.description,
     icons: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const { messages } = await getServerI18n();
 
   return {
-    title: messages.metadata.homeTitle,
+    title: `${messages.metadata.homeTitle} · tempoll.app`,
     description: messages.metadata.description,
   };
 }


### PR DESCRIPTION
## Summary
- update the global metadata title default and template to use `tempoll.app`
- set the home page title explicitly to `Startseite · tempoll.app` so the brand is present on the root route

## Testing
- Not run (not requested)