### PR TITLE
Fix mobile navbar compression and align header control sizing

### DIFF
--- a/src/components/app-chrome.test.tsx
+++ b/src/components/app-chrome.test.tsx
@@ -82,4 +82,17 @@ describe("AppChrome", () => {
 
     expect(screen.getByAltText("tempoll")).toHaveAttribute("src", "/tempoll-logo-2.png");
   });
+
+  it("keeps compact header controls accessible via full labels", () => {
+    renderWithI18n(
+      <AppChrome appName="tempoll" setupComplete legalPagesEnabled={false}>
+        <div>content</div>
+      </AppChrome>,
+      { locale: "de" },
+    );
+
+    expect(screen.getByRole("combobox", { name: "Sprache" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Neues Event" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Letzte Events" })).toBeInTheDocument();
+  });
 });

--- a/src/components/app-chrome.tsx
+++ b/src/components/app-chrome.tsx
@@ -41,36 +41,57 @@ export function AppChrome({
   return (
     <>
       <header className="border-b bg-background/90 backdrop-blur supports-[backdrop-filter]:bg-background/70">
-        <div className="app-shell flex h-16 items-center justify-between gap-4">
+        <div className="app-shell flex min-h-16 flex-wrap items-center justify-between gap-x-2 gap-y-3 py-3 sm:flex-nowrap sm:gap-4">
           <Link
             href="/"
-            className="inline-flex items-center text-lg font-semibold tracking-tight"
+            className="inline-flex shrink-0 items-center text-base font-semibold tracking-tight sm:text-lg"
           >
             {showLogo && logoSrc ? (
               // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={logoSrc}
                 alt={appName}
-                className="h-7 w-auto shrink-0"
+                className="block h-7 w-auto shrink-0"
                 onError={() => setFailedLogoSrc(logoSrc)}
               />
             ) : (
               appName
             )}
           </Link>
-          <nav className="flex items-center gap-2">
-            <LanguageSwitcher className="h-9 min-w-28" />
+          <nav className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-1.5 sm:flex-nowrap sm:gap-2">
+            <LanguageSwitcher
+              className="h-9 min-w-16 px-2.5 text-xs sm:min-w-28 sm:px-3 sm:text-sm"
+              compactLabel
+            />
             <Link
               href="/new"
-              className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}
+              aria-label={messages.appChrome.newEvent}
+              className={cn(
+                buttonVariants({ variant: "ghost" }),
+                "h-9 px-3 text-xs sm:px-4 sm:text-sm",
+              )}
             >
-              {messages.appChrome.newEvent}
+              <span aria-hidden="true" className="sm:hidden">
+                {messages.appChrome.newEventCompact}
+              </span>
+              <span aria-hidden="true" className="hidden sm:inline">
+                {messages.appChrome.newEvent}
+              </span>
             </Link>
             <Link
               href="/#recent-events"
-              className={cn(buttonVariants({ variant: "outline", size: "sm" }))}
+              aria-label={messages.appChrome.recentEvents}
+              className={cn(
+                buttonVariants({ variant: "outline" }),
+                "h-9 px-3 text-xs sm:px-4 sm:text-sm",
+              )}
             >
-              {messages.appChrome.recentEvents}
+              <span aria-hidden="true" className="sm:hidden">
+                {messages.appChrome.recentEventsCompact}
+              </span>
+              <span aria-hidden="true" className="hidden sm:inline">
+                {messages.appChrome.recentEvents}
+              </span>
             </Link>
           </nav>
         </div>

--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -17,12 +17,17 @@ const oneYearInSeconds = 60 * 60 * 24 * 365;
 
 type LanguageSwitcherProps = {
   className?: string;
+  compactLabel?: boolean;
 };
 
-export function LanguageSwitcher({ className }: LanguageSwitcherProps) {
+export function LanguageSwitcher({
+  className,
+  compactLabel = false,
+}: LanguageSwitcherProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const { locale, messages } = useI18n();
+  const currentLocaleLabel = getLocaleLabel(messages.languageSwitcher, locale);
 
   function handleValueChange(nextLocale: string) {
     if (nextLocale === locale) {
@@ -42,7 +47,18 @@ export function LanguageSwitcher({ className }: LanguageSwitcherProps) {
         className={className}
         disabled={isPending}
       >
-        <SelectValue />
+        {compactLabel ? (
+          <>
+            <span aria-hidden="true" className="sm:hidden">
+              {getCompactLocaleLabel(locale)}
+            </span>
+            <span aria-hidden="true" className="hidden sm:inline">
+              {currentLocaleLabel}
+            </span>
+          </>
+        ) : (
+          <SelectValue />
+        )}
       </SelectTrigger>
       <SelectContent>
         {supportedLocales.map((supportedLocale) => (
@@ -63,4 +79,8 @@ function getLocaleLabel(
   locale: AppLocale,
 ) {
   return locale === "de" ? labels.de : labels.en;
+}
+
+function getCompactLocaleLabel(locale: AppLocale) {
+  return locale.toUpperCase();
 }

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -42,7 +42,9 @@ export const en = {
   },
   appChrome: {
     newEvent: "New event",
+    newEventCompact: "New",
     recentEvents: "Recent events",
+    recentEventsCompact: "Recent",
     footerDescription:
       "{appName} is a self-hostable, realtime scheduling board for modern teams.",
     featureRequest: "Feature request or suggestion",
@@ -603,7 +605,9 @@ export const de: Messages = {
   },
   appChrome: {
     newEvent: "Neues Event",
+    newEventCompact: "Neu",
     recentEvents: "Letzte Events",
+    recentEventsCompact: "Events",
     footerDescription:
       "{appName} ist ein selbst hostbares Echtzeit-Planungsboard für moderne Teams.",
     featureRequest: "Feature-Wunsch oder Vorschlag",


### PR DESCRIPTION
## Summary
- prevent the app logo from being compressed by allowing the header layout to wrap and keeping the brand area non-shrinking
- add compact mobile labels for the language switcher, new event, and recent events controls
- standardize header control height so the language dropdown matches the recent events button
- cover the compact header behavior with an accessibility-focused component test

## Testing
- `pnpm verify`