### PR TITLE
Update app chrome responsiveness and make heatmap intensity relative to current overlap

### DIFF
--- a/src/components/event-heatmap.tsx
+++ b/src/components/event-heatmap.tsx
@@ -70,32 +70,34 @@ function slotKey(dateKey: string, minutes: number) {
   return `${dateKey}-${minutes}`;
 }
 
-function getHeatColor(availabilityCount: number) {
-  if (availabilityCount >= 6) {
+function getHeatColor(availabilityCount: number, maxAvailabilityCount: number) {
+  if (availabilityCount <= 0 || maxAvailabilityCount <= 0) {
+    return "bg-background";
+  }
+
+  const ratio = availabilityCount / maxAvailabilityCount;
+
+  if (ratio >= 1) {
     return "bg-primary/80";
   }
 
-  if (availabilityCount === 5) {
+  if (ratio >= 0.8) {
     return "bg-primary/65";
   }
 
-  if (availabilityCount === 4) {
+  if (ratio >= 0.6) {
     return "bg-primary/50";
   }
 
-  if (availabilityCount === 3) {
+  if (ratio >= 0.4) {
     return "bg-primary/36";
   }
 
-  if (availabilityCount === 2) {
+  if (ratio >= 0.2) {
     return "bg-primary/24";
   }
 
-  if (availabilityCount === 1) {
-    return "bg-primary/12";
-  }
-
-  return "bg-background";
+  return "bg-primary/12";
 }
 
 function getCurrentUserSelectionClass(isSelected: boolean) {
@@ -405,6 +407,16 @@ export function EventHeatmap({
       ),
     [currentParticipantId, effectiveSelectedMap, snapshot.slots],
   );
+  const maxAvailabilityCount = useMemo(
+    () =>
+      Array.from(slotMap.values()).reduce(
+        (currentMax, slot) => Math.max(currentMax, slot.availabilityCount),
+        0,
+      ),
+    [slotMap],
+  );
+  const someOverlapLegendClass = getHeatColor(maxAvailabilityCount > 0 ? 1 : 0, maxAvailabilityCount);
+  const highOverlapLegendClass = getHeatColor(maxAvailabilityCount, maxAvailabilityCount);
   const dateLabelsByKey = useMemo(
     () => new Map(snapshot.dates.map((date) => [date.dateKey, date.label])),
     [snapshot.dates],
@@ -782,11 +794,11 @@ export function EventHeatmap({
                   {messages.publicEvent.legendEmpty}
                 </span>
                 <span className="inline-flex items-center gap-1">
-                  <span className="size-3 rounded-[3px] bg-primary/24" />
+                  <span className={cn("size-3 rounded-[3px]", someOverlapLegendClass)} />
                   {messages.publicEvent.legendSomeOverlap}
                 </span>
                 <span className="inline-flex items-center gap-1">
-                  <span className="size-3 rounded-[3px] bg-primary/65" />
+                  <span className={cn("size-3 rounded-[3px]", highOverlapLegendClass)} />
                   {messages.publicEvent.legendHighOverlap}
                 </span>
                 {supportsPainting && mode === "edit" ? (
@@ -1004,7 +1016,9 @@ export function EventHeatmap({
                               mode === "edit" && supportsPainting
                                 ? "cursor-crosshair touch-none hover:brightness-[0.98]"
                                 : "cursor-pointer hover:brightness-[0.99]",
-                              isInFinalSlotWindow ? "" : getHeatColor(slot.availabilityCount),
+                              isInFinalSlotWindow
+                                ? ""
+                                : getHeatColor(slot.availabilityCount, maxAvailabilityCount),
                               getCurrentUserSelectionClass(showCurrentUserSelection),
                               getActiveViewSelectionClass(isActiveViewSlot),
                               getFinalizedSlotClass(isInFinalSlotWindow),

--- a/src/components/public-event-client.test.tsx
+++ b/src/components/public-event-client.test.tsx
@@ -102,6 +102,33 @@ function createSnapshot(options?: {
   };
 }
 
+function recalculateParticipantSelectionCounts(snapshot: PublicEventSnapshot) {
+  const selectedSlotCountByParticipant = new Map(
+    snapshot.participants.map((participant) => [participant.id, 0]),
+  );
+
+  for (const slot of snapshot.slots) {
+    for (const participantId of slot.participantIds) {
+      selectedSlotCountByParticipant.set(
+        participantId,
+        (selectedSlotCountByParticipant.get(participantId) ?? 0) + 1,
+      );
+    }
+  }
+
+  snapshot.participants = snapshot.participants.map((participant) => ({
+    ...participant,
+    selectedSlotCount: selectedSlotCountByParticipant.get(participant.id) ?? 0,
+  }));
+
+  if (snapshot.currentParticipant) {
+    snapshot.currentParticipant = {
+      ...snapshot.currentParticipant,
+      selectedSlotCount: selectedSlotCountByParticipant.get(snapshot.currentParticipant.id) ?? 0,
+    };
+  }
+}
+
 function setViewportWidth(width: number) {
   Object.defineProperty(window, "innerWidth", {
     configurable: true,
@@ -193,8 +220,74 @@ describe("PublicEventClient", () => {
     });
 
     expect(cell).toHaveAttribute("data-current-user-selected", "true");
-    expect(cell.className).toContain("bg-primary/24");
+    expect(cell.className).toContain("bg-primary/80");
     expect(screen.queryByText("Slot details")).not.toBeInTheDocument();
+  });
+
+  it("uses relative overlap buckets for cells and legend based on the current maximum overlap", () => {
+    const snapshot = createSnapshot({ withCurrentUser: false });
+    snapshot.slots = snapshot.slots.map((slot) => {
+      if (slot.slotStart === "2026-03-30T07:00:00.000Z") {
+        return {
+          ...slot,
+          participantIds: ["p1", "p2", "p3"],
+          availabilityCount: 3,
+        };
+      }
+
+      if (slot.slotStart === "2026-03-31T07:00:00.000Z") {
+        return {
+          ...slot,
+          participantIds: ["p1", "p2"],
+          availabilityCount: 2,
+        };
+      }
+
+      if (slot.slotStart === "2026-03-30T07:30:00.000Z") {
+        return {
+          ...slot,
+          participantIds: ["p1"],
+          availabilityCount: 1,
+        };
+      }
+
+      return {
+        ...slot,
+        participantIds: [],
+        availabilityCount: 0,
+      };
+    });
+    recalculateParticipantSelectionCounts(snapshot);
+
+    renderWithI18n(
+      <PublicEventClient
+        slug="test-event"
+        initialSnapshot={snapshot}
+        initialSession={null}
+      />,
+    );
+
+    const countThreeCell = screen.getByRole("button", {
+      name: /Mon, Mar 30 09:00 · 3\/4 available/i,
+    });
+    const countTwoCell = screen.getByRole("button", {
+      name: /Tue, Mar 31 09:00 · 2\/4 available/i,
+    });
+    const countOneCell = screen.getByRole("button", {
+      name: /Mon, Mar 30 09:30 · 1\/4 available/i,
+    });
+
+    expect(countThreeCell.className).toContain("bg-primary/80");
+    expect(countTwoCell.className).toContain("bg-primary/50");
+    expect(countOneCell.className).toContain("bg-primary/24");
+
+    const someOverlapSwatch = screen.getByText("some overlap").querySelector("span");
+    const highOverlapSwatch = screen.getByText("high overlap").querySelector("span");
+
+    expect(someOverlapSwatch).not.toBeNull();
+    expect(highOverlapSwatch).not.toBeNull();
+    expect(someOverlapSwatch?.className).toContain("bg-primary/24");
+    expect(highOverlapSwatch?.className).toContain("bg-primary/80");
   });
 
   it("switches to view mode and shows available plus unavailable participants for a slot", () => {


### PR DESCRIPTION
## Summary
- lock browser metadata branding to `tempoll.app` for default and templated page titles
- compact the app chrome controls for small screens with icon-first actions while preserving accessible labels
- add a `mobileIcon` mode to `LanguageSwitcher` with locale label fallback on larger screens
- switch heatmap color intensity from absolute counts to relative scaling against the current max overlap
- align heatmap legend swatches with the same relative overlap scale
- add/adjust tests for compact header accessibility, language switcher icon rendering, and relative heatmap coloring

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:run src/components/public-event-client.test.tsx`