### PR TITLE
Update app chrome controls and normalize heatmap intensity to dynamic overlap maxima

### DIFF
--- a/src/components/event-heatmap.tsx
+++ b/src/components/event-heatmap.tsx
@@ -105,7 +105,7 @@ function getCurrentUserSelectionClass(isSelected: boolean) {
     return "";
   }
 
-  return "outline outline-2 -outline-offset-2 outline-primary/85 ring-2 ring-inset ring-background";
+  return "outline outline-2 -outline-offset-2 outline-primary ring-2 ring-inset ring-background";
 }
 
 function getActiveViewSelectionClass(isActive: boolean) {
@@ -803,7 +803,7 @@ export function EventHeatmap({
                 </span>
                 {supportsPainting && mode === "edit" ? (
                   <span className="inline-flex items-center gap-1">
-                    <span className="size-3 rounded-[3px] bg-primary/24 outline outline-2 -outline-offset-2 outline-primary/85 ring-1 ring-inset ring-background" />
+                    <span className="size-3 rounded-[3px] bg-primary/24 outline outline-2 -outline-offset-2 outline-primary ring-1 ring-inset ring-background" />
                     {messages.publicEvent.legendYourAvailability}
                   </span>
                 ) : null}

--- a/src/components/public-event-client.test.tsx
+++ b/src/components/public-event-client.test.tsx
@@ -221,6 +221,7 @@ describe("PublicEventClient", () => {
 
     expect(cell).toHaveAttribute("data-current-user-selected", "true");
     expect(cell.className).toContain("bg-primary/80");
+    expect(cell.className).toContain("outline-primary");
     expect(screen.queryByText("Slot details")).not.toBeInTheDocument();
   });
 
@@ -310,7 +311,7 @@ describe("PublicEventClient", () => {
 
     expect(screen.queryByText("your availability")).not.toBeInTheDocument();
     expect(cell).not.toHaveAttribute("data-current-user-selected");
-    expect(cell.className).not.toContain("outline-primary/85");
+    expect(cell.className).not.toContain("outline-primary");
 
     fireEvent.click(cell);
 


### PR DESCRIPTION
### Summary
- Set browser metadata branding to `tempoll.app` for default and templated page titles
- Compact header controls for small screens using icon variants while preserving accessible labels for language, new event, and recent events
- Add mobile-icon mode to `LanguageSwitcher` with locale label fallback on larger screens
- Change heatmap coloring from absolute counts to relative scaling against the current maximum overlap
- Sync legend swatches with the same relative heatmap scale and add/adjust tests for accessibility and overlap-color behavior

### Testing
- Not run (not requested)