### PR TITLE
Add public URL share card to the public event sidebar

### DIFF
--- a/src/app/e/[slug]/page.tsx
+++ b/src/app/e/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { PublicEventClient } from "@/components/public-event-client";
 import { RecentEventTracker } from "@/components/recent-event-tracker";
 import { getPublicEventSnapshot } from "@/lib/event-service";
 import { getServerI18n } from "@/lib/i18n/server";
-import { getParticipantCookieName } from "@/lib/tokens";
+import { buildPublicEventUrl, getParticipantCookieName } from "@/lib/tokens";
 
 type EventPageProps = {
   params: Promise<{
@@ -35,6 +35,7 @@ export default async function EventPage({ params }: EventPageProps) {
       />
       <PublicEventClient
         slug={slug}
+        shareUrl={buildPublicEventUrl(slug)}
         initialSnapshot={event.snapshot}
         initialSession={
           event.participant

--- a/src/components/public-event-client.test.tsx
+++ b/src/components/public-event-client.test.tsx
@@ -124,6 +124,7 @@ describe("PublicEventClient", () => {
     renderWithI18n(
       <PublicEventClient
         slug="test-event"
+        shareUrl="https://tempoll.app/e/test-event"
         initialSnapshot={createSnapshot()}
         initialSession={{
           participantId: "p1",
@@ -136,6 +137,9 @@ describe("PublicEventClient", () => {
     expect(screen.getByRole("button", { name: "Bearbeiten" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Ansehen" })).toBeInTheDocument();
     expect(screen.getByText("Verfügbarkeit")).toBeInTheDocument();
+    expect(screen.getByText("Board teilen")).toBeInTheDocument();
+    expect(screen.getByText("https://tempoll.app/e/test-event")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Öffentliche URL kopieren" })).toBeInTheDocument();
   });
 
   it("hides best matching windows before anyone has selected availability", () => {

--- a/src/components/public-event-client.tsx
+++ b/src/components/public-event-client.tsx
@@ -4,6 +4,7 @@ import { Loader2Icon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
+import { CopyButton } from "@/components/copy-button";
 import { EventHeatmap, type BoardMode, type DraftSelection } from "@/components/event-heatmap";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -14,6 +15,7 @@ import type { PublicEventSnapshot, RealtimeEventPayload } from "@/lib/types";
 
 type PublicEventClientProps = {
   slug: string;
+  shareUrl?: string;
   initialSnapshot: PublicEventSnapshot;
   initialSession:
     | {
@@ -49,10 +51,12 @@ function getSelectedSlotStarts(snapshot: PublicEventSnapshot) {
 
 export function PublicEventClient({
   slug,
+  shareUrl,
   initialSnapshot,
   initialSession,
 }: PublicEventClientProps) {
   const { messages, format, plural } = useI18n();
+  const publicShareUrl = shareUrl ?? `/e/${initialSnapshot.slug}`;
   const saveAvailabilityFallback = messages.errors.routeFallbacks.saveAvailability;
   const initialHasEditableSession = Boolean(initialSession && initialSnapshot.status === "OPEN");
   const [snapshot, setSnapshot] = useState(initialSnapshot);
@@ -277,10 +281,30 @@ export function PublicEventClient({
     [canEdit],
   );
 
-  const sidebarTopContent =
+  const shareCard = (
+    <Card>
+      <CardHeader className="p-4 pb-2">
+        <CardTitle className="text-sm">{messages.publicEvent.shareTitle}</CardTitle>
+        <CardDescription className="text-xs">
+          {messages.publicEvent.shareDescription}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 p-4 pt-0">
+        <div className="space-y-2">
+          <Label>{messages.publicEvent.shareUrlLabel}</Label>
+          <div className="rounded-md border bg-muted/20 px-3 py-2 text-sm text-muted-foreground [overflow-wrap:anywhere]">
+            {publicShareUrl}
+          </div>
+        </div>
+        <CopyButton value={publicShareUrl} label={messages.publicEvent.copyShareUrl} />
+      </CardContent>
+    </Card>
+  );
+
+  const scheduleSummaryCard =
     snapshot.status === "CLOSED" && snapshot.finalizedSlot ? (
-        <Card>
-          <CardHeader className="p-4 pb-2">
+      <Card>
+        <CardHeader className="p-4 pb-2">
           <CardTitle className="text-sm">{messages.common.fixedDate}</CardTitle>
           <CardDescription className="text-xs">
             {messages.publicEvent.fixedDateDescription}
@@ -339,6 +363,13 @@ export function PublicEventClient({
         </CardContent>
       </Card>
     ) : null;
+
+  const sidebarTopContent = (
+    <>
+      {shareCard}
+      {scheduleSummaryCard}
+    </>
+  );
 
   return (
     <div className="space-y-4">

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -185,6 +185,10 @@ export const en = {
     yourNamePlaceholder: "Alex, Nora, Product team...",
     joinButton: "Join event",
     joined: "You joined the event",
+    shareTitle: "Share this board",
+    shareDescription: "Copy the public event URL and send it to participants.",
+    shareUrlLabel: "Public event URL",
+    copyShareUrl: "Copy public URL",
     availabilityTitle: "Availability",
     availabilityDescriptionEditWindowed:
       "Tap or drag to paint your availability. Use the arrows to move day by day.",
@@ -750,6 +754,11 @@ export const de: Messages = {
     yourNamePlaceholder: "Alex, Nora, Produktteam...",
     joinButton: "Event beitreten",
     joined: "Du bist dem Event beigetreten",
+    shareTitle: "Board teilen",
+    shareDescription:
+      "Kopiere die öffentliche Event-URL und teile sie mit den Teilnehmenden.",
+    shareUrlLabel: "Öffentliche Event-URL",
+    copyShareUrl: "Öffentliche URL kopieren",
     availabilityTitle: "Verfügbarkeit",
     availabilityDescriptionEditWindowed:
       "Tippe oder ziehe, um deine Verfügbarkeit zu markieren. Mit den Pfeilen bewegst du dich tageweise weiter.",


### PR DESCRIPTION
## Summary
- pass the full public event URL into the public event client
- show a share card in the public page sidebar with the public URL and copy action
- add localized copy for the new share card in English and German
- extend the public event client test to cover the new sidebar content

## Testing
- `pnpm verify`