### PR TITLE
Refactor organizer event closing into direct fixed-date actions

### DIFF
--- a/src/app/api/manage/[token]/route.test.ts
+++ b/src/app/api/manage/[token]/route.test.ts
@@ -32,10 +32,8 @@ describe("PATCH /api/manage/[token]", () => {
       new Request("https://tempoll.example.com/api/manage/invalid-token", {
         method: "PATCH",
         body: JSON.stringify({
-          action: "updateEvent",
+          action: "updateTitle",
           title: "Updated title",
-          status: "OPEN",
-          finalSlotStart: null,
         }),
         headers: {
           "Accept-Language": "en-US",
@@ -64,10 +62,8 @@ describe("PATCH /api/manage/[token]", () => {
       new Request("https://tempoll.example.com/api/manage/invalid-token", {
         method: "PATCH",
         body: JSON.stringify({
-          action: "updateEvent",
+          action: "updateTitle",
           title: "Updated title",
-          status: "OPEN",
-          finalSlotStart: null,
         }),
         headers: {
           "Accept-Language": "en-US",

--- a/src/components/event-heatmap.tsx
+++ b/src/components/event-heatmap.tsx
@@ -5,6 +5,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   Clock3Icon,
+  Loader2Icon,
   LockIcon,
   UsersIcon,
 } from "lucide-react";
@@ -52,8 +53,9 @@ type EventHeatmapProps = {
   onUpdateCell?: (dateKey: string, minutes: number, nextValue?: boolean) => boolean;
   displayStatus?: PublicEventSnapshot["status"];
   finalSlotStart: string | null;
-  allowFinalSlotSelection?: boolean;
-  onFinalSlotSelect?: (slotStart: string) => void;
+  showFixedDateAction?: boolean;
+  onFixedDateAction?: (slotStart: string) => void;
+  isFixedDateActionPending?: boolean;
   sessionBadgeLabel?: string | null;
   showModeToggle?: boolean;
   showSidebar?: boolean;
@@ -267,8 +269,9 @@ export function EventHeatmap({
   onUpdateCell,
   displayStatus = snapshot.status,
   finalSlotStart,
-  allowFinalSlotSelection = false,
-  onFinalSlotSelect,
+  showFixedDateAction = false,
+  onFixedDateAction,
+  isFixedDateActionPending = false,
   sessionBadgeLabel = null,
   showModeToggle = true,
   showSidebar = true,
@@ -729,6 +732,7 @@ export function EventHeatmap({
         },
         messages,
       );
+  const shouldShowFixedDateAction = showFixedDateAction && Boolean(onFixedDateAction);
 
   return (
     <div
@@ -1133,7 +1137,7 @@ export function EventHeatmap({
                       </div>
                     </div>
 
-                    {allowFinalSlotSelection ? (
+                    {shouldShowFixedDateAction ? (
                       <div className="rounded-md border bg-background/70 p-3">
                         {activeSlotDetails.isValidFinalSlotStart ? (
                           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -1144,18 +1148,30 @@ export function EventHeatmap({
                                 })}
                               </p>
                               <p className="text-xs text-muted-foreground">
-                                {messages.publicEvent.finalSlotFitsDescription}
+                                {displayStatus === "OPEN"
+                                  ? messages.manageEvent.fixedDateActionCloseDescription
+                                  : activeSlotDetails.isFinalSlotStart
+                                    ? messages.manageEvent.fixedDateActionSelectedDescription
+                                    : messages.manageEvent.fixedDateActionUpdateDescription}
                               </p>
                             </div>
                             <Button
                               type="button"
                               size="sm"
                               variant={activeSlotDetails.isFinalSlotStart ? "secondary" : "default"}
-                              onClick={() => onFinalSlotSelect?.(activeSlotDetails.slot.slotStart)}
+                              disabled={
+                                isFixedDateActionPending || activeSlotDetails.isFinalSlotStart
+                              }
+                              onClick={() => onFixedDateAction?.(activeSlotDetails.slot.slotStart)}
                             >
-                              {activeSlotDetails.isFinalSlotStart
-                                ? messages.common.fixedDateSelected
-                                : messages.common.setFixedDate}
+                              {isFixedDateActionPending ? (
+                                <Loader2Icon className="size-4 animate-spin" />
+                              ) : null}
+                              {displayStatus === "OPEN"
+                                ? messages.manageEvent.setFixedDateAndCloseEvent
+                                : activeSlotDetails.isFinalSlotStart
+                                  ? messages.common.fixedDateSelected
+                                  : messages.manageEvent.updateFixedDate}
                             </Button>
                           </div>
                         ) : (

--- a/src/components/manage-event-client.test.tsx
+++ b/src/components/manage-event-client.test.tsx
@@ -1,9 +1,18 @@
-import { fireEvent, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ManageEventClient } from "./manage-event-client";
+import { buildFinalizedSlot } from "@/lib/availability";
+import type { ManageEventView, PublicEventSnapshot } from "@/lib/types";
 import { renderWithI18n } from "@/test/render-with-i18n";
-import type { ManageEventView } from "@/lib/types";
+import { ManageEventClient } from "./manage-event-client";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
 
 function createManageView(options?: {
   status?: "OPEN" | "CLOSED";
@@ -92,6 +101,92 @@ function createManageView(options?: {
   };
 }
 
+function buildPublishedFinalizedSlot(
+  snapshot: PublicEventSnapshot,
+  finalSlotStart: string,
+): NonNullable<PublicEventSnapshot["finalizedSlot"]> {
+  const finalizedSlot = buildFinalizedSlot({
+    dates: snapshot.dates.map((date) => date.dateKey),
+    locale: "en",
+    timezone: snapshot.timezone,
+    dayStartMinutes: snapshot.dayStartMinutes,
+    dayEndMinutes: snapshot.dayEndMinutes,
+    slotMinutes: snapshot.slotMinutes,
+    meetingDurationMinutes: snapshot.meetingDurationMinutes,
+    slots: snapshot.slots,
+    finalSlotStart,
+  });
+
+  if (!finalizedSlot) {
+    throw new Error(`Could not build finalized slot for ${finalSlotStart}`);
+  }
+
+  return finalizedSlot;
+}
+
+function installManageFetchMock(view: ManageEventView) {
+  let currentSnapshot = structuredClone(view.snapshot) as PublicEventSnapshot;
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+
+    if (url === `/api/events/${view.snapshot.slug}`) {
+      return {
+        ok: true,
+        json: async () => ({
+          snapshot: currentSnapshot,
+        }),
+      };
+    }
+
+    if (url === `/api/manage/${view.manageKey}` && init?.method === "PATCH") {
+      const payload = JSON.parse(String(init.body)) as
+        | { action: "updateTitle"; title: string }
+        | { action: "closeEvent"; finalSlotStart: string }
+        | { action: "updateFixedDate"; finalSlotStart: string }
+        | { action: "reopenEvent" };
+
+      switch (payload.action) {
+        case "updateTitle":
+          currentSnapshot = {
+            ...currentSnapshot,
+            title: payload.title.trim(),
+          };
+          break;
+        case "closeEvent":
+        case "updateFixedDate":
+          currentSnapshot = {
+            ...currentSnapshot,
+            status: "CLOSED",
+            finalizedSlot: buildPublishedFinalizedSlot(currentSnapshot, payload.finalSlotStart),
+          };
+          break;
+        case "reopenEvent":
+          currentSnapshot = {
+            ...currentSnapshot,
+            status: "OPEN",
+            finalizedSlot: null,
+          };
+          break;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ ok: true }),
+      };
+    }
+
+    throw new Error(`Unhandled fetch call: ${url}`);
+  });
+
+  global.fetch = fetchMock as unknown as typeof fetch;
+
+  return fetchMock;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("ManageEventClient", () => {
   it("keeps long share links wrappable inside the sidebar cards", () => {
     const view = createManageView();
@@ -136,29 +231,135 @@ describe("ManageEventClient", () => {
     expect(heatmapLayout?.className).not.toContain("xl:grid-cols-[minmax(0,1fr)_250px]");
   });
 
-  it("renders the heatmap and lets the organizer select a fixed date on closed events", () => {
-    const view = createManageView({ status: "CLOSED" });
+  it("closes the event directly from the selected slot without requiring a separate save", async () => {
+    const user = userEvent.setup();
+    const view = createManageView();
+    const fetchMock = installManageFetchMock(view);
     renderWithI18n(<ManageEventClient initialView={view} />);
 
-    expect(screen.getByText("Availability")).toBeInTheDocument();
-
-    fireEvent.click(
+    await user.click(
       screen.getByRole("button", {
         name: /Thu, Apr 2 09:00 · 2\/2 available/i,
       }),
     );
 
+    expect(screen.getByText("This slot fits the full 60-minute meeting.")).toBeInTheDocument();
     expect(
-      screen.getByText("This slot fits the full 60-minute meeting."),
+      screen.getByRole("button", { name: "Set fixed date and close event" }),
     ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save title" })).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Set fixed date" }));
+    await user.click(screen.getByRole("button", { name: "Set fixed date and close event" }));
 
-    const fixedDateCard = screen.getByText("Fixed date").closest("[data-slot='card']");
+    await waitFor(() => {
+      expect(screen.getAllByText("Closed").length).toBeGreaterThan(0);
+      expect(screen.getByRole("link", { name: "Add to calendar (.ics)" })).toBeInTheDocument();
+    });
 
-    expect(fixedDateCard).not.toBeNull();
-    expect(within(fixedDateCard as HTMLElement).getByText(/Thu, Apr 2.*09:00.*10:00/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled();
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(requestInit.body))).toMatchObject({
+      action: "closeEvent",
+      finalSlotStart: "2026-04-02T07:00:00.000Z",
+    });
+  });
+
+  it("updates the published fixed date directly on closed events", async () => {
+    const user = userEvent.setup();
+    const initialFinalizedSlot = buildPublishedFinalizedSlot(
+      createManageView().snapshot,
+      "2026-04-02T07:00:00.000Z",
+    );
+    const view = createManageView({
+      status: "CLOSED",
+      finalizedSlot: initialFinalizedSlot,
+    });
+    const fetchMock = installManageFetchMock(view);
+    renderWithI18n(<ManageEventClient initialView={view} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /Thu, Apr 2 09:30 · 2\/2 available/i,
+      }),
+    );
+
+    expect(screen.getByRole("button", { name: "Update fixed date" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Update fixed date" }));
+
+    await waitFor(() => {
+      const fixedDateCard = screen
+        .getAllByText("Fixed date")
+        .find((element) => element.closest("[data-slot='card']"))
+        ?.closest("[data-slot='card']");
+
+      expect(fixedDateCard).not.toBeNull();
+      expect(
+        within(fixedDateCard as HTMLElement).getByText(/Thu, Apr 2.*09:30.*10:30/i),
+      ).toBeInTheDocument();
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(requestInit.body))).toMatchObject({
+      action: "updateFixedDate",
+      finalSlotStart: "2026-04-02T07:30:00.000Z",
+    });
+  });
+
+  it("requires confirmation before reopening a closed event", async () => {
+    const user = userEvent.setup();
+    const initialFinalizedSlot = buildPublishedFinalizedSlot(
+      createManageView().snapshot,
+      "2026-04-02T07:00:00.000Z",
+    );
+    const view = createManageView({
+      status: "CLOSED",
+      finalizedSlot: initialFinalizedSlot,
+    });
+    const fetchMock = installManageFetchMock(view);
+    renderWithI18n(<ManageEventClient initialView={view} />);
+
+    await user.click(screen.getByRole("button", { name: "Reopen event" }));
+
+    expect(screen.getByText("Reopen this event?")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Reopen and clear fixed date" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Open for edits")).toBeInTheDocument();
+      expect(screen.queryByText("Reopen this event?")).not.toBeInTheDocument();
+      expect(screen.queryAllByText("Fixed date")).toHaveLength(0);
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(requestInit.body))).toMatchObject({
+      action: "reopenEvent",
+    });
+  });
+
+  it("saves the title independently from closing and reopening actions", async () => {
+    const user = userEvent.setup();
+    const view = createManageView();
+    const fetchMock = installManageFetchMock(view);
+    renderWithI18n(<ManageEventClient initialView={view} />);
+
+    await user.clear(screen.getByLabelText("Title"));
+    await user.type(screen.getByLabelText("Title"), "Updated team sync");
+
+    const saveTitleButton = screen.getByRole("button", { name: "Save title" });
+    expect(saveTitleButton).toBeInTheDocument();
+
+    await user.click(saveTitleButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Save title" })).not.toBeInTheDocument();
+      expect(screen.getByDisplayValue("Updated team sync")).toBeInTheDocument();
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(requestInit.body))).toMatchObject({
+      action: "updateTitle",
+      title: "Updated team sync",
+    });
   });
 
   it("shows the saved fixed date with an .ics export link", () => {
@@ -176,7 +377,7 @@ describe("ManageEventClient", () => {
     });
     renderWithI18n(<ManageEventClient initialView={view} />);
 
-    expect(screen.getByText("Fixed date")).toBeInTheDocument();
+    expect(screen.getAllByText("Fixed date").length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: "Add to calendar (.ics)" })).toHaveAttribute(
       "href",
       "/api/events/test-event-xeqlxw/ics",

--- a/src/components/manage-event-client.tsx
+++ b/src/components/manage-event-client.tsx
@@ -1,24 +1,28 @@
 "use client";
 
 import Link from "next/link";
-import { Loader2Icon, Trash2Icon } from "lucide-react";
+import { Loader2Icon, LockIcon, Trash2Icon, UnlockIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
 
 import { EventHeatmap } from "@/components/event-heatmap";
 import { CopyButton } from "@/components/copy-button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { buildFinalizedSlot } from "@/lib/availability";
 import { useI18n } from "@/lib/i18n/context";
 import type { ManageEventView, PublicEventSnapshot } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -27,17 +31,27 @@ type ManageEventClientProps = {
   initialView: ManageEventView;
 };
 
+type PendingAction =
+  | "updateTitle"
+  | "closeEvent"
+  | "updateFixedDate"
+  | "reopenEvent"
+  | "renameParticipant"
+  | "removeParticipant";
+
+type RefreshSnapshotOptions = {
+  preserveDirtyTitle?: boolean;
+};
+
 export function ManageEventClient({ initialView }: ManageEventClientProps) {
-  const { messages, format, plural, locale } = useI18n();
+  const { messages, format, plural } = useI18n();
   const [snapshot, setSnapshot] = useState<PublicEventSnapshot>(initialView.snapshot);
   const [title, setTitle] = useState(initialView.snapshot.title);
-  const [status, setStatus] = useState(initialView.snapshot.status);
-  const [finalSlotStart, setFinalSlotStart] = useState<string | null>(
-    initialView.snapshot.finalizedSlot?.slotStart ?? null,
-  );
   const [requestedActiveParticipantId, setRequestedActiveParticipantId] = useState<string | null>(
     null,
   );
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+  const [isReopenDialogOpen, setIsReopenDialogOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
   const hasAnyAvailability = snapshot.participants.some(
     (participant) => participant.selectedSlotCount > 0,
@@ -49,155 +63,234 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
         : null,
     [requestedActiveParticipantId, snapshot.participants],
   );
-  const draftFinalizedSlot = useMemo(() => {
-    if (status !== "CLOSED" || !finalSlotStart) {
-      return null;
-    }
+  const savedFinalSlot = snapshot.status === "CLOSED" ? snapshot.finalizedSlot : null;
+  const isTitleDirty = title !== snapshot.title;
+  const manageActionUrl = `/api/manage/${initialView.manageKey}`;
 
-    return buildFinalizedSlot({
-      dates: snapshot.dates.map((date) => date.dateKey),
-      locale,
-      timezone: snapshot.timezone,
-      dayStartMinutes: snapshot.dayStartMinutes,
-      dayEndMinutes: snapshot.dayEndMinutes,
-      slotMinutes: snapshot.slotMinutes,
-      meetingDurationMinutes: snapshot.meetingDurationMinutes,
-      slots: snapshot.slots,
-      finalSlotStart,
-    });
-  }, [
-    finalSlotStart,
-    locale,
-    snapshot.dates,
-    snapshot.dayEndMinutes,
-    snapshot.dayStartMinutes,
-    snapshot.meetingDurationMinutes,
-    snapshot.slotMinutes,
-    snapshot.slots,
-    snapshot.timezone,
-    status,
-  ]);
-  const isClosingWithoutFixedDate = status === "CLOSED" && !draftFinalizedSlot;
+  const refreshSnapshot = useCallback(
+    async ({ preserveDirtyTitle = false }: RefreshSnapshotOptions = {}) => {
+      const response = await fetch(`/api/events/${initialView.snapshot.slug}`, {
+        cache: "no-store",
+      });
 
-  const refreshSnapshot = useCallback(async () => {
-    const response = await fetch(`/api/events/${initialView.snapshot.slug}`, {
-      cache: "no-store",
-    });
+      if (!response.ok) {
+        return;
+      }
 
-    if (!response.ok) {
-      return;
-    }
-
-    const payload = (await response.json()) as { snapshot: PublicEventSnapshot };
-    setSnapshot(payload.snapshot);
-    setTitle(payload.snapshot.title);
-    setStatus(payload.snapshot.status);
-    setFinalSlotStart(payload.snapshot.finalizedSlot?.slotStart ?? null);
-  }, [initialView.snapshot.slug]);
+      const payload = (await response.json()) as { snapshot: PublicEventSnapshot };
+      setSnapshot(payload.snapshot);
+      setTitle((currentTitle) =>
+        preserveDirtyTitle && currentTitle !== snapshot.title ? currentTitle : payload.snapshot.title,
+      );
+    },
+    [initialView.snapshot.slug, snapshot.title],
+  );
 
   useEffect(() => {
     const eventSource = new EventSource(`/api/events/${initialView.snapshot.slug}/stream`);
     eventSource.addEventListener("event-update", () => {
-      void refreshSnapshot();
+      void refreshSnapshot({ preserveDirtyTitle: true });
     });
 
     return () => eventSource.close();
   }, [initialView.snapshot.slug, refreshSnapshot]);
 
-  function updateEvent() {
-    if (isClosingWithoutFixedDate) {
-      toast.error(messages.manageEvent.closeRequiresFixedDate);
+  function performManageAction(
+    action: PendingAction,
+    request: () => Promise<Response>,
+    {
+      errorMessage,
+      onSuccess,
+      preserveDirtyTitleOnRefresh = true,
+      successMessage,
+    }: {
+      successMessage: string;
+      errorMessage: string;
+      preserveDirtyTitleOnRefresh?: boolean;
+      onSuccess?: () => Promise<void> | void;
+    },
+  ) {
+    setPendingAction(action);
+
+    startTransition(async () => {
+      try {
+        const response = await request();
+        const payload = (await response.json()) as { error?: string };
+        if (!response.ok) {
+          toast.error(payload.error ?? errorMessage);
+          return;
+        }
+
+        toast.success(successMessage);
+
+        if (onSuccess) {
+          await onSuccess();
+          return;
+        }
+
+        await refreshSnapshot({
+          preserveDirtyTitle: preserveDirtyTitleOnRefresh,
+        });
+      } finally {
+        setPendingAction(null);
+      }
+    });
+  }
+
+  function saveTitle() {
+    performManageAction(
+      "updateTitle",
+      () =>
+        fetch(manageActionUrl, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            action: "updateTitle",
+            title,
+          }),
+        }),
+      {
+        successMessage: messages.manageEvent.titleSaved,
+        errorMessage: messages.errors.routeFallbacks.updateEvent,
+        preserveDirtyTitleOnRefresh: false,
+      },
+    );
+  }
+
+  function closeEvent(finalSlotStart: string) {
+    performManageAction(
+      "closeEvent",
+      () =>
+        fetch(manageActionUrl, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            action: "closeEvent",
+            finalSlotStart,
+          }),
+        }),
+      {
+        successMessage: messages.manageEvent.eventClosed,
+        errorMessage: messages.errors.routeFallbacks.updateEvent,
+      },
+    );
+  }
+
+  function updateFixedDate(finalSlotStart: string) {
+    performManageAction(
+      "updateFixedDate",
+      () =>
+        fetch(manageActionUrl, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            action: "updateFixedDate",
+            finalSlotStart,
+          }),
+        }),
+      {
+        successMessage: messages.manageEvent.fixedDateUpdated,
+        errorMessage: messages.errors.routeFallbacks.updateEvent,
+      },
+    );
+  }
+
+  function reopenEvent() {
+    performManageAction(
+      "reopenEvent",
+      () =>
+        fetch(manageActionUrl, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            action: "reopenEvent",
+          }),
+        }),
+      {
+        successMessage: messages.manageEvent.eventReopened,
+        errorMessage: messages.errors.routeFallbacks.updateEvent,
+        onSuccess: async () => {
+          setIsReopenDialogOpen(false);
+          await refreshSnapshot({
+            preserveDirtyTitle: true,
+          });
+        },
+      },
+    );
+  }
+
+  function handleFixedDateAction(slotStart: string) {
+    if (snapshot.status === "OPEN") {
+      closeEvent(slotStart);
       return;
     }
 
-    startTransition(async () => {
-      const response = await fetch(`/api/manage/${initialView.manageKey}`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          action: "updateEvent",
-          title,
-          status,
-          finalSlotStart: status === "CLOSED" ? finalSlotStart : null,
-        }),
-      });
-
-      const payload = (await response.json()) as { error?: string };
-      if (!response.ok) {
-        toast.error(payload.error ?? messages.errors.routeFallbacks.updateEvent);
-        return;
-      }
-
-      toast.success(messages.manageEvent.eventUpdated);
-      await refreshSnapshot();
-    });
-  }
-
-  function renameParticipant(participantId: string, displayName: string) {
-    startTransition(async () => {
-      const response = await fetch(`/api/manage/${initialView.manageKey}`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          action: "renameParticipant",
-          participantId,
-          displayName,
-        }),
-      });
-
-      const payload = (await response.json()) as { error?: string };
-      if (!response.ok) {
-        toast.error(payload.error ?? messages.errors.routeFallbacks.updateEvent);
-        return;
-      }
-
-      toast.success(messages.manageEvent.participantRenamed);
-      setSnapshot((current) => ({
-        ...current,
-        participants: current.participants.map((participant) =>
-          participant.id === participantId ? { ...participant, displayName } : participant,
-        ),
-      }));
-    });
-  }
-
-  function removeParticipant(participantId: string) {
-    startTransition(async () => {
-      const response = await fetch(
-        `/api/manage/${initialView.manageKey}/participants/${participantId}`,
-        {
-          method: "DELETE",
-        },
-      );
-
-      const payload = (await response.json()) as { error?: string };
-      if (!response.ok) {
-        toast.error(payload.error ?? messages.errors.routeFallbacks.removeParticipant);
-        return;
-      }
-
-      toast.success(messages.manageEvent.participantRemoved);
-      if (participantId === requestedActiveParticipantId) {
-        setRequestedActiveParticipantId(null);
-      }
-      await refreshSnapshot();
-    });
-  }
-
-  function handleStatusChange(nextStatus: "OPEN" | "CLOSED") {
-    setStatus(nextStatus);
-    if (nextStatus === "OPEN") {
-      setFinalSlotStart(null);
+    if (savedFinalSlot?.slotStart !== slotStart) {
+      updateFixedDate(slotStart);
     }
   }
 
-  const savedFinalSlot = snapshot.status === "CLOSED" ? snapshot.finalizedSlot : null;
-  const hasSavedFixedDate =
-    Boolean(savedFinalSlot) && savedFinalSlot?.slotStart === draftFinalizedSlot?.slotStart;
+  function renameParticipant(participantId: string, displayName: string) {
+    performManageAction(
+      "renameParticipant",
+      () =>
+        fetch(manageActionUrl, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            action: "renameParticipant",
+            participantId,
+            displayName,
+          }),
+        }),
+      {
+        successMessage: messages.manageEvent.participantRenamed,
+        errorMessage: messages.errors.routeFallbacks.updateEvent,
+        onSuccess: () => {
+          setSnapshot((current) => ({
+            ...current,
+            participants: current.participants.map((participant) =>
+              participant.id === participantId ? { ...participant, displayName } : participant,
+            ),
+          }));
+        },
+      },
+    );
+  }
+
+  function removeParticipant(participantId: string) {
+    performManageAction(
+      "removeParticipant",
+      () =>
+        fetch(`/api/manage/${initialView.manageKey}/participants/${participantId}`, {
+          method: "DELETE",
+        }),
+      {
+        successMessage: messages.manageEvent.participantRemoved,
+        errorMessage: messages.errors.routeFallbacks.removeParticipant,
+        onSuccess: async () => {
+          if (participantId === requestedActiveParticipantId) {
+            setRequestedActiveParticipantId(null);
+          }
+
+          await refreshSnapshot({
+            preserveDirtyTitle: true,
+          });
+        },
+      },
+    );
+  }
+
   const bestWindowsCard = hasAnyAvailability ? (
     <Card>
       <CardHeader className="p-4 pb-2">
@@ -223,42 +316,29 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
       </CardContent>
     </Card>
   ) : null;
-  const fixedDateCard = draftFinalizedSlot ? (
+
+  const fixedDateCard = savedFinalSlot ? (
     <Card>
       <CardHeader className="p-4 pb-2">
         <CardTitle className="text-sm">{messages.common.fixedDate}</CardTitle>
         <CardDescription className="text-xs">
-          {hasSavedFixedDate
-            ? messages.manageEvent.fixedDatePublishedDescription
-            : messages.manageEvent.fixedDateDraftDescription}
+          {messages.manageEvent.fixedDatePublishedDescription}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3 p-4 pt-0">
         <div className="rounded-md border bg-muted/20 px-3 py-2">
-          <p className="text-sm font-semibold text-foreground">{draftFinalizedSlot.label}</p>
+          <p className="text-sm font-semibold text-foreground">{savedFinalSlot.label}</p>
           <p className="mt-1 text-[11px] text-muted-foreground">
-            {plural(messages.publicEvent.fullWindowFree, draftFinalizedSlot.availableCount)}
+            {plural(messages.publicEvent.fullWindowFree, savedFinalSlot.availableCount)}
           </p>
         </div>
-        <div className="flex flex-col gap-2">
-          {hasSavedFixedDate ? (
-            <Button asChild size="sm" className="w-full">
-              <a href={`/api/events/${snapshot.slug}/ics`}>{messages.common.addToCalendar}</a>
-            </Button>
-          ) : null}
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            className="w-full"
-            onClick={() => setFinalSlotStart(null)}
-          >
-            {messages.common.clearFixedDate}
-          </Button>
-        </div>
+        <Button asChild size="sm" className="w-full">
+          <a href={`/api/events/${snapshot.slug}/ics`}>{messages.common.addToCalendar}</a>
+        </Button>
       </CardContent>
     </Card>
   ) : null;
+
   const sidebarSummaryCards = fixedDateCard ? (
     <>
       {fixedDateCard}
@@ -267,6 +347,7 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
   ) : (
     bestWindowsCard
   );
+
   const participantsCard = (
     <Card>
       <CardHeader className="p-4 pb-2">
@@ -364,43 +445,88 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
       <Card className="overflow-hidden">
         <CardHeader>
           <CardTitle className="text-3xl">{messages.manageEvent.title}</CardTitle>
-          <CardDescription>
-            {messages.manageEvent.description}
-          </CardDescription>
+          <CardDescription>{messages.manageEvent.description}</CardDescription>
         </CardHeader>
-        <CardContent className="grid gap-x-6 gap-y-5 lg:grid-cols-2 lg:items-end">
+        <CardContent className="grid gap-x-6 gap-y-5 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start">
           <div className="space-y-2">
             <Label htmlFor="title">{messages.manageEvent.titleLabel}</Label>
-            <Input id="title" value={title} onChange={(event) => setTitle(event.target.value)} />
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+              <Input id="title" value={title} onChange={(event) => setTitle(event.target.value)} />
+              {isTitleDirty ? (
+                <Button
+                  type="button"
+                  onClick={saveTitle}
+                  disabled={isPending}
+                  className="sm:shrink-0"
+                >
+                  {pendingAction === "updateTitle" ? (
+                    <Loader2Icon className="size-4 animate-spin" />
+                  ) : null}
+                  {messages.manageEvent.saveTitle}
+                </Button>
+              ) : null}
+            </div>
           </div>
-          <div className="space-y-2">
-            <Label>{messages.manageEvent.statusLabel}</Label>
-            <Select
-              value={status}
-              onValueChange={(value) => handleStatusChange(value as "OPEN" | "CLOSED")}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="OPEN">{messages.manageEvent.statusOpen}</SelectItem>
-                <SelectItem value="CLOSED">{messages.manageEvent.statusClosed}</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="space-y-3 lg:col-span-2">
-            <Button
-              onClick={updateEvent}
-              disabled={isPending || isClosingWithoutFixedDate}
-              className="h-10"
-            >
-              {isPending ? <Loader2Icon className="size-4 animate-spin" /> : null}
-              {messages.common.saveChanges}
-            </Button>
-            {isClosingWithoutFixedDate ? (
-              <p className="text-sm text-destructive">
-                {messages.manageEvent.closeRequiresFixedDateInHeatmap}
+
+          <div className="space-y-3 rounded-xl border bg-muted/15 p-4">
+            <div className="space-y-2">
+              <Label>{messages.manageEvent.statusLabel}</Label>
+              <Badge
+                variant={snapshot.status === "CLOSED" ? "destructive" : "secondary"}
+                className="h-7 w-fit gap-1.5 px-2.5 text-xs"
+              >
+                {snapshot.status === "CLOSED" ? (
+                  <LockIcon className="size-3.5" />
+                ) : (
+                  <UnlockIcon className="size-3.5" />
+                )}
+                {snapshot.status === "CLOSED"
+                  ? messages.manageEvent.statusClosed
+                  : messages.manageEvent.statusOpen}
+              </Badge>
+              <p className="text-sm text-muted-foreground">
+                {snapshot.status === "CLOSED"
+                  ? messages.manageEvent.statusClosedDescription
+                  : messages.manageEvent.statusOpenDescription}
               </p>
+            </div>
+
+            {savedFinalSlot ? (
+              <div className="rounded-md border bg-background/80 px-3 py-2">
+                <p className="text-[11px] font-medium tracking-[0.14em] text-muted-foreground uppercase">
+                  {messages.common.fixedDate}
+                </p>
+                <p className="mt-1 text-sm font-semibold text-foreground">{savedFinalSlot.label}</p>
+              </div>
+            ) : null}
+
+            {snapshot.status === "CLOSED" ? (
+              <AlertDialog open={isReopenDialogOpen} onOpenChange={setIsReopenDialogOpen}>
+                <AlertDialogTrigger asChild>
+                  <Button type="button" variant="outline" disabled={isPending}>
+                    {messages.manageEvent.reopenEvent}
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>
+                      {messages.manageEvent.reopenEventConfirmTitle}
+                    </AlertDialogTitle>
+                    <AlertDialogDescription>
+                      {messages.manageEvent.reopenEventConfirmDescription}
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>{messages.common.cancel}</AlertDialogCancel>
+                    <AlertDialogAction onClick={reopenEvent} disabled={isPending}>
+                      {pendingAction === "reopenEvent" ? (
+                        <Loader2Icon className="size-4 animate-spin" />
+                      ) : null}
+                      {messages.manageEvent.reopenEventConfirmAction}
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
             ) : null}
           </div>
         </CardContent>
@@ -411,9 +537,7 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
           <Card>
             <CardHeader>
               <CardTitle>{messages.manageEvent.shareLinksTitle}</CardTitle>
-              <CardDescription>
-                {messages.manageEvent.shareLinksDescription}
-              </CardDescription>
+              <CardDescription>{messages.manageEvent.shareLinksDescription}</CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
@@ -449,14 +573,17 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
             canEdit={false}
             showModeToggle={false}
             showSidebar={false}
-            displayStatus={status}
-            finalSlotStart={status === "CLOSED" ? finalSlotStart : null}
-            allowFinalSlotSelection={status === "CLOSED"}
-            onFinalSlotSelect={setFinalSlotStart}
+            displayStatus={snapshot.status}
+            finalSlotStart={savedFinalSlot?.slotStart ?? null}
+            showFixedDateAction
+            isFixedDateActionPending={
+              pendingAction === "closeEvent" || pendingAction === "updateFixedDate"
+            }
+            onFixedDateAction={handleFixedDateAction}
             activeParticipantId={activeParticipantId}
             onActiveParticipantChange={setRequestedActiveParticipantId}
             getDescription={({ usesDateWindowing }) =>
-              status === "CLOSED"
+              snapshot.status === "CLOSED"
                 ? usesDateWindowing
                   ? messages.manageEvent.closedHeatmapDescriptionWindowed
                   : messages.manageEvent.closedHeatmapDescription

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+const AlertDialog = DialogPrimitive.Root
+
+const AlertDialogTrigger = DialogPrimitive.Trigger
+
+const AlertDialogPortal = DialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+))
+AlertDialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = DialogPrimitive.Content.displayName
+
+function AlertDialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
+}
+
+function AlertDialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)} {...props} />
+  )
+}
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName = DialogPrimitive.Description.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<typeof Button>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Close asChild>
+    <Button ref={ref} type="button" variant="outline" className={className} {...props} />
+  </DialogPrimitive.Close>
+))
+AlertDialogCancel.displayName = "AlertDialogCancel"
+
+const AlertDialogAction = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<typeof Button>
+>(({ className, ...props }, ref) => (
+  <Button ref={ref} type="button" className={className} {...props} />
+))
+AlertDialogAction.displayName = "AlertDialogAction"
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/src/lib/event-service.test.ts
+++ b/src/lib/event-service.test.ts
@@ -61,31 +61,12 @@ describe("updateManagedEvent", () => {
     publishEventUpdate.mockResolvedValue(undefined);
   });
 
-  it("requires a fixed date before closing an event", async () => {
-    const { updateManagedEvent } = await import("./event-service");
-
-    await expect(
-      updateManagedEvent("event_1.secret", {
-        action: "updateEvent",
-        title: "Closed title",
-        status: "CLOSED",
-        finalSlotStart: null,
-      }),
-    ).rejects.toMatchObject({
-      code: "final_slot_required",
-    });
-
-    expect(prisma.event.update).not.toHaveBeenCalled();
-  });
-
   it("stores a valid fixed date when closing an event", async () => {
     const { updateManagedEvent } = await import("./event-service");
     const finalSlotStart = buildSlotStart("2026-04-02", 9 * 60, "Europe/Vienna");
 
     await updateManagedEvent("event_1.secret", {
-      action: "updateEvent",
-      title: "Closed title",
-      status: "CLOSED",
+      action: "closeEvent",
       finalSlotStart,
     });
 
@@ -94,22 +75,33 @@ describe("updateManagedEvent", () => {
         id: "event_1",
       },
       data: {
-        title: "Closed title",
         status: "CLOSED",
         finalSlotStartAt: new Date(finalSlotStart),
       },
     });
   });
 
+  it("rejects invalid fixed date updates", async () => {
+    const { updateManagedEvent } = await import("./event-service");
+    const invalidFinalSlotStart = buildSlotStart("2026-04-02", 10 * 60 + 30, "Europe/Vienna");
+
+    await expect(
+      updateManagedEvent("event_1.secret", {
+        action: "updateFixedDate",
+        finalSlotStart: invalidFinalSlotStart,
+      }),
+    ).rejects.toMatchObject({
+      code: "final_slot_invalid",
+    });
+
+    expect(prisma.event.update).not.toHaveBeenCalled();
+  });
+
   it("clears the fixed date when reopening an event", async () => {
     const { updateManagedEvent } = await import("./event-service");
-    const finalSlotStart = buildSlotStart("2026-04-02", 9 * 60, "Europe/Vienna");
 
     await updateManagedEvent("event_1.secret", {
-      action: "updateEvent",
-      title: "Open title",
-      status: "OPEN",
-      finalSlotStart,
+      action: "reopenEvent",
     });
 
     expect(prisma.event.update).toHaveBeenCalledWith({
@@ -117,9 +109,26 @@ describe("updateManagedEvent", () => {
         id: "event_1",
       },
       data: {
-        title: "Open title",
         status: "OPEN",
         finalSlotStartAt: null,
+      },
+    });
+  });
+
+  it("updates only the title when requested", async () => {
+    const { updateManagedEvent } = await import("./event-service");
+
+    await updateManagedEvent("event_1.secret", {
+      action: "updateTitle",
+      title: "Renamed sync",
+    });
+
+    expect(prisma.event.update).toHaveBeenCalledWith({
+      where: {
+        id: "event_1",
+      },
+      data: {
+        title: "Renamed sync",
       },
     });
   });

--- a/src/lib/event-service.ts
+++ b/src/lib/event-service.ts
@@ -454,10 +454,19 @@ export async function updateManagedEvent(
   manageKey: string,
   input:
     | {
-        action: "updateEvent";
+        action: "updateTitle";
         title: string;
-        status: "OPEN" | "CLOSED";
-        finalSlotStart: string | null;
+      }
+    | {
+        action: "closeEvent";
+        finalSlotStart: string;
+      }
+    | {
+        action: "updateFixedDate";
+        finalSlotStart: string;
+      }
+    | {
+        action: "reopenEvent";
       }
     | {
         action: "renameParticipant";
@@ -467,38 +476,54 @@ export async function updateManagedEvent(
 ) {
   const event = await verifyManageKey(manageKey);
 
-  if (input.action === "updateEvent") {
-    let finalSlotStartAt: Date | null = null;
+  function parseFinalSlotStart(finalSlotStart: string) {
+    const allowedFinalSlotStarts = getAllowedFinalSlotStarts({
+      dates: event.dates.map((date) => date.dateKey),
+      timezone: event.timezone,
+      dayStartMinutes: event.dayStartMinutes,
+      dayEndMinutes: event.dayEndMinutes,
+      slotMinutes: event.slotMinutes,
+      meetingDurationMinutes: event.meetingDurationMinutes,
+    });
 
-    if (input.status === "CLOSED") {
-      if (!input.finalSlotStart) {
-        throw conflict("final_slot_required");
-      }
-
-      const allowedFinalSlotStarts = getAllowedFinalSlotStarts({
-        dates: event.dates.map((date) => date.dateKey),
-        timezone: event.timezone,
-        dayStartMinutes: event.dayStartMinutes,
-        dayEndMinutes: event.dayEndMinutes,
-        slotMinutes: event.slotMinutes,
-        meetingDurationMinutes: event.meetingDurationMinutes,
-      });
-
-      if (!allowedFinalSlotStarts.has(input.finalSlotStart)) {
-        throw conflict("final_slot_invalid");
-      }
-
-      finalSlotStartAt = new Date(input.finalSlotStart);
+    if (!allowedFinalSlotStarts.has(finalSlotStart)) {
+      throw conflict("final_slot_invalid");
     }
 
+    return new Date(finalSlotStart);
+  }
+
+  if (input.action === "updateTitle") {
     await prisma.event.update({
       where: {
         id: event.id,
       },
       data: {
         title: input.title,
-        status: input.status,
-        finalSlotStartAt,
+      },
+    });
+  }
+
+  if (input.action === "closeEvent" || input.action === "updateFixedDate") {
+    await prisma.event.update({
+      where: {
+        id: event.id,
+      },
+      data: {
+        status: "CLOSED",
+        finalSlotStartAt: parseFinalSlotStart(input.finalSlotStart),
+      },
+    });
+  }
+
+  if (input.action === "reopenEvent") {
+    await prisma.event.update({
+      where: {
+        id: event.id,
+      },
+      data: {
+        status: "OPEN",
+        finalSlotStartAt: null,
       },
     });
   }

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -231,12 +231,20 @@ export const en = {
     description:
       "Share the public board, keep the private organizer URL safe and control whether new changes are still allowed.",
     eventUpdated: "Event updated",
+    titleSaved: "Title saved",
+    eventClosed: "Event closed",
+    fixedDateUpdated: "Fixed date updated",
+    eventReopened: "Event reopened",
     participantRenamed: "Participant renamed",
     participantRemoved: "Participant removed",
     titleLabel: "Title",
+    saveTitle: "Save title",
     statusLabel: "Status",
     statusOpen: "Open for edits",
     statusClosed: "Closed",
+    statusOpenDescription: "Pick a slot in the heatmap to publish the fixed date and close the event.",
+    statusClosedDescription:
+      "This event is closed. Reopen it if participants should be able to edit availability again.",
     participantsTitle: "Participants",
     participantsDescription:
       "Click a row to highlight availability. Rename participants or remove accidental entries.",
@@ -253,17 +261,30 @@ export const en = {
       "This is the published fixed date for the closed event.",
     fixedDateDraftDescription:
       "This fixed date is selected locally and will be published after saving.",
+    setFixedDateAndCloseEvent: "Set fixed date and close event",
+    updateFixedDate: "Update fixed date",
+    fixedDateActionCloseDescription:
+      "This will publish the fixed date immediately and stop further edits.",
+    fixedDateActionUpdateDescription:
+      "This will publish this slot as the new fixed date immediately.",
+    fixedDateActionSelectedDescription:
+      "This slot is already published as the fixed date.",
+    reopenEvent: "Reopen event",
+    reopenEventConfirmTitle: "Reopen this event?",
+    reopenEventConfirmDescription:
+      "Participants will be able to edit availability again and the published fixed date will be cleared.",
+    reopenEventConfirmAction: "Reopen and clear fixed date",
     closeRequiresFixedDate: "Pick a fixed date before closing this event.",
     closeRequiresFixedDateInHeatmap:
       "Pick a fixed date in the heatmap before closing this event.",
     closedHeatmapDescription:
-      "Click any slot to inspect availability and set the fixed date for this closed event.",
+      "Click any slot to inspect availability and update the published fixed date for this closed event.",
     closedHeatmapDescriptionWindowed:
-      "Select a slot to inspect overlap and use the button below to set the fixed date. Use the arrows to move through the date range.",
+      "Select a slot to inspect overlap and update the fixed date directly below. Use the arrows to move through the date range.",
     openHeatmapDescription:
-      "Click any slot to inspect availability. Close the event when you are ready to choose the fixed date.",
+      "Click any slot to inspect availability and close the event directly from the slot action.",
     openHeatmapDescriptionWindowed:
-      "Select a slot to inspect availability. Close the event to choose the fixed date.",
+      "Select a slot to inspect availability and close the event directly from the slot action. Use the arrows to move through the date range.",
     peopleAvailable: {
       one: "{count} person available",
       other: "{count} people available",
@@ -799,12 +820,21 @@ export const de: Messages = {
     description:
       "Teile das öffentliche Board, bewahre die private Organizer-URL sicher auf und steuere, ob weitere Änderungen noch erlaubt sind.",
     eventUpdated: "Event aktualisiert",
+    titleSaved: "Titel gespeichert",
+    eventClosed: "Event geschlossen",
+    fixedDateUpdated: "Fixer Termin aktualisiert",
+    eventReopened: "Event wieder geöffnet",
     participantRenamed: "Teilnehmende Person umbenannt",
     participantRemoved: "Teilnehmende Person entfernt",
     titleLabel: "Titel",
+    saveTitle: "Titel speichern",
     statusLabel: "Status",
     statusOpen: "Für Änderungen geöffnet",
     statusClosed: "Geschlossen",
+    statusOpenDescription:
+      "Wähle in der Heatmap einen Slot aus, um den fixen Termin zu veröffentlichen und das Event zu schließen.",
+    statusClosedDescription:
+      "Dieses Event ist geschlossen. Öffne es wieder, wenn Teilnehmende ihre Verfügbarkeit erneut bearbeiten dürfen.",
     participantsTitle: "Teilnehmende",
     participantsDescription:
       "Klicke auf eine Zeile, um die Verfügbarkeit hervorzuheben. Benenne Teilnehmende zur besseren Übersicht um oder entferne versehentliche Einträge.",
@@ -821,18 +851,31 @@ export const de: Messages = {
       "Das ist der veröffentlichte feste Termin für das geschlossene Event.",
     fixedDateDraftDescription:
       "Dieser feste Termin ist lokal ausgewählt und wird nach dem Speichern veröffentlicht.",
+    setFixedDateAndCloseEvent: "Fixen Termin setzen und Event schließen",
+    updateFixedDate: "Fixen Termin aktualisieren",
+    fixedDateActionCloseDescription:
+      "Dadurch wird der feste Termin sofort veröffentlicht und weitere Änderungen werden gestoppt.",
+    fixedDateActionUpdateDescription:
+      "Dadurch wird dieser Slot sofort als neuer fixer Termin veröffentlicht.",
+    fixedDateActionSelectedDescription:
+      "Dieser Slot ist bereits als fixer Termin veröffentlicht.",
+    reopenEvent: "Event wieder öffnen",
+    reopenEventConfirmTitle: "Dieses Event wieder öffnen?",
+    reopenEventConfirmDescription:
+      "Teilnehmende können ihre Verfügbarkeit danach wieder bearbeiten und der veröffentlichte feste Termin wird entfernt.",
+    reopenEventConfirmAction: "Wieder öffnen und fixen Termin entfernen",
     closeRequiresFixedDate:
       "Wähle ein fixes Datum aus, bevor du dieses Event schließt.",
     closeRequiresFixedDateInHeatmap:
       "Wähle in der Heatmap ein fixes Datum aus, bevor du dieses Event schließt.",
     closedHeatmapDescription:
-      "Klicke auf einen beliebigen Slot, um die Verfügbarkeit zu prüfen und den fixen Termin für dieses geschlossene Event zu setzen.",
+      "Klicke auf einen beliebigen Slot, um die Verfügbarkeit zu prüfen und den veröffentlichten fixen Termin für dieses geschlossene Event zu aktualisieren.",
     closedHeatmapDescriptionWindowed:
-      "Wähle einen Slot aus, um die Überschneidung zu prüfen, und nutze den Button darunter, um den fixen Termin zu setzen. Mit den Pfeilen bewegst du dich durch den Datumsbereich.",
+      "Wähle einen Slot aus, um die Überschneidung zu prüfen, und aktualisiere den fixen Termin direkt darunter. Mit den Pfeilen bewegst du dich durch den Datumsbereich.",
     openHeatmapDescription:
-      "Klicke auf einen beliebigen Slot, um die Verfügbarkeit zu prüfen. Schließe das Event, wenn du bereit bist, den fixen Termin auszuwählen.",
+      "Klicke auf einen beliebigen Slot, um die Verfügbarkeit zu prüfen und das Event direkt über die Slot-Aktion zu schließen.",
     openHeatmapDescriptionWindowed:
-      "Wähle einen Slot aus, um die Verfügbarkeit zu prüfen. Schließe das Event, um den fixen Termin auszuwählen.",
+      "Wähle einen Slot aus, um die Verfügbarkeit zu prüfen und das Event direkt über die Slot-Aktion zu schließen. Mit den Pfeilen bewegst du dich durch den Datumsbereich.",
     peopleAvailable: {
       one: "{count} Person verfügbar",
       other: "{count} Personen verfügbar",

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -77,14 +77,23 @@ export function createAvailabilityMutationSchema() {
 export function createManageUpdateSchema(messages: Messages) {
   return z.discriminatedUnion("action", [
     z.object({
-      action: z.literal("updateEvent"),
+      action: z.literal("updateTitle"),
       title: z
         .string()
         .trim()
         .min(3, messages.validation.eventCreate.titleMin)
         .max(80, messages.validation.eventCreate.titleMax),
-      status: z.enum(["OPEN", "CLOSED"]),
-      finalSlotStart: z.string().datetime().nullable(),
+    }),
+    z.object({
+      action: z.literal("closeEvent"),
+      finalSlotStart: z.string().datetime(),
+    }),
+    z.object({
+      action: z.literal("updateFixedDate"),
+      finalSlotStart: z.string().datetime(),
+    }),
+    z.object({
+      action: z.literal("reopenEvent"),
     }),
     z.object({
       action: z.literal("renameParticipant"),


### PR DESCRIPTION
## Summary
- replace the organizer status dropdown flow with direct slot-based actions in the manage view
- separate title saving from closing, reopening, and fixed-date updates
- add explicit organizer API actions for updating the title, closing, reopening, and changing the fixed date
- add a confirmation dialog for reopening closed events and update related copy and tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:run src/components/manage-event-client.test.tsx src/lib/event-service.test.ts 'src/app/api/manage/[token]/route.test.ts'`