### PR TITLE
Refactor organizer event closing flow and simplify manage view UI

### DIFF
--- a/src/components/event-heatmap.tsx
+++ b/src/components/event-heatmap.tsx
@@ -53,6 +53,8 @@ type EventHeatmapProps = {
   onUpdateCell?: (dateKey: string, minutes: number, nextValue?: boolean) => boolean;
   displayStatus?: PublicEventSnapshot["status"];
   finalSlotStart: string | null;
+  showStatusBadge?: boolean;
+  showTitleBlock?: boolean;
   showFixedDateAction?: boolean;
   onFixedDateAction?: (slotStart: string) => void;
   isFixedDateActionPending?: boolean;
@@ -269,6 +271,8 @@ export function EventHeatmap({
   onUpdateCell,
   displayStatus = snapshot.status,
   finalSlotStart,
+  showStatusBadge = true,
+  showTitleBlock = true,
   showFixedDateAction = false,
   onFixedDateAction,
   isFixedDateActionPending = false,
@@ -745,7 +749,14 @@ export function EventHeatmap({
       <div className="min-w-0 space-y-4">
         <Card className="min-w-0 overflow-hidden">
           <CardHeader className="gap-3 p-4">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div
+              className={cn(
+                "flex flex-col gap-3",
+                showTitleBlock || showStatusBadge
+                  ? "lg:flex-row lg:items-start lg:justify-between"
+                  : undefined,
+              )}
+            >
               <div className="space-y-2">
                 <div className="flex flex-wrap items-center gap-2 text-[10px] font-medium tracking-[0.16em] text-muted-foreground uppercase">
                   <span className="inline-flex items-center gap-1">
@@ -761,16 +772,18 @@ export function EventHeatmap({
                     {plural(messages.publicEvent.participantsSummary, snapshot.participants.length)}
                   </span>
                 </div>
-                <div>
-                  <CardTitle className="text-2xl">{snapshot.title}</CardTitle>
-                  <CardDescription className="mt-1 text-xs">
-                    {format(messages.publicEvent.timesShownIn, {
-                      timezone: snapshot.timezone,
-                    })}
-                  </CardDescription>
-                </div>
+                {showTitleBlock ? (
+                  <div>
+                    <CardTitle className="text-2xl">{snapshot.title}</CardTitle>
+                    <CardDescription className="mt-1 text-xs">
+                      {format(messages.publicEvent.timesShownIn, {
+                        timezone: snapshot.timezone,
+                      })}
+                    </CardDescription>
+                  </div>
+                ) : null}
               </div>
-              {displayStatus === "CLOSED" ? (
+              {showStatusBadge && displayStatus === "CLOSED" ? (
                 <Badge variant="destructive" className="h-7 px-2.5 text-xs">
                   <LockIcon className="size-3.5" />
                   {messages.common.closed}

--- a/src/components/manage-event-client.test.tsx
+++ b/src/components/manage-event-client.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -196,16 +196,21 @@ describe("ManageEventClient", () => {
     expect(screen.getByText(view.manageUrl).className).toContain("[overflow-wrap:anywhere]");
   });
 
-  it("places share links and the organizer sidebar stack before the heatmap in DOM order", () => {
+  it("places the unified organizer sidebar stack before the heatmap in DOM order", () => {
     const view = createManageView();
     renderWithI18n(<ManageEventClient initialView={view} />);
 
+    const eventStatusHeading = screen.getByText("Event status");
     const shareLinksHeading = screen.getByText("Share links");
     const bestWindowsHeading = screen.getByText("Best windows right now");
     const participantsHeading = screen.getByText("Participants");
     const availabilityHeading = screen.getByText("Availability");
 
     expect(screen.getAllByText("Participants")).toHaveLength(1);
+    expect(
+      eventStatusHeading.compareDocumentPosition(shareLinksHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(
       shareLinksHeading.compareDocumentPosition(availabilityHeading) &
         Node.DOCUMENT_POSITION_FOLLOWING,
@@ -220,7 +225,7 @@ describe("ManageEventClient", () => {
     ).toBeTruthy();
   });
 
-  it("renders the heatmap as a single content column when the embedded sidebar is disabled", () => {
+  it("keeps the top manage card compact and renders the heatmap as a single content column", () => {
     const view = createManageView();
     renderWithI18n(<ManageEventClient initialView={view} />);
 
@@ -229,6 +234,7 @@ describe("ManageEventClient", () => {
     expect(heatmapLayout).not.toBeNull();
     expect(heatmapLayout).toHaveClass("grid-cols-1");
     expect(heatmapLayout?.className).not.toContain("xl:grid-cols-[minmax(0,1fr)_250px]");
+    expect(document.body.innerHTML).not.toContain("lg:grid-cols-[minmax(0,1fr)_22rem]");
   });
 
   it("closes the event directly from the selected slot without requiring a separate save", async () => {
@@ -287,15 +293,7 @@ describe("ManageEventClient", () => {
     await user.click(screen.getByRole("button", { name: "Update fixed date" }));
 
     await waitFor(() => {
-      const fixedDateCard = screen
-        .getAllByText("Fixed date")
-        .find((element) => element.closest("[data-slot='card']"))
-        ?.closest("[data-slot='card']");
-
-      expect(fixedDateCard).not.toBeNull();
-      expect(
-        within(fixedDateCard as HTMLElement).getByText(/Thu, Apr 2.*09:30.*10:30/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/Thu, Apr 2.*09:30.*10:30/i)).toBeInTheDocument();
     });
 
     const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
@@ -377,11 +375,28 @@ describe("ManageEventClient", () => {
     });
     renderWithI18n(<ManageEventClient initialView={view} />);
 
-    expect(screen.getAllByText("Fixed date").length).toBeGreaterThan(0);
+    expect(screen.getByText("Event status")).toBeInTheDocument();
+    expect(screen.getAllByText("Fixed date")).toHaveLength(1);
+    expect(screen.getAllByText("Closed")).toHaveLength(1);
+    expect(screen.queryByText("Times shown in Europe/Vienna")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Add to calendar (.ics)" })).toHaveAttribute(
       "href",
       "/api/events/test-event-xeqlxw/ics",
     );
+  });
+
+  it("hides duplicate closed-state suggestions when the published fixed date already matches the best slot", () => {
+    const finalizedSlot = buildPublishedFinalizedSlot(
+      createManageView().snapshot,
+      "2026-04-02T07:00:00.000Z",
+    );
+    const view = createManageView({
+      status: "CLOSED",
+      finalizedSlot,
+    });
+    renderWithI18n(<ManageEventClient initialView={view} />);
+
+    expect(screen.queryByText("Best windows right now")).not.toBeInTheDocument();
   });
 
   it("combines participant management and highlighting in one sidebar card", () => {

--- a/src/components/manage-event-client.tsx
+++ b/src/components/manage-event-client.tsx
@@ -66,6 +66,9 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
   const savedFinalSlot = snapshot.status === "CLOSED" ? snapshot.finalizedSlot : null;
   const isTitleDirty = title !== snapshot.title;
   const manageActionUrl = `/api/manage/${initialView.manageKey}`;
+  const visibleSuggestions = savedFinalSlot
+    ? snapshot.suggestions.filter((suggestion) => suggestion.slotStart !== savedFinalSlot.slotStart)
+    : snapshot.suggestions;
 
   const refreshSnapshot = useCallback(
     async ({ preserveDirtyTitle = false }: RefreshSnapshotOptions = {}) => {
@@ -291,7 +294,7 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
     );
   }
 
-  const bestWindowsCard = hasAnyAvailability ? (
+  const bestWindowsCard = hasAnyAvailability && visibleSuggestions.length > 0 ? (
     <Card>
       <CardHeader className="p-4 pb-2">
         <CardTitle className="text-sm">{messages.manageEvent.bestWindowsTitle}</CardTitle>
@@ -302,7 +305,7 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-2 p-4 pt-0">
-        {snapshot.suggestions.map((suggestion, index) => (
+        {visibleSuggestions.map((suggestion, index) => (
           <div key={suggestion.slotStart} className="rounded-md border bg-muted/20 px-3 py-2">
             <p className="text-[11px] font-medium text-muted-foreground">
               {format(messages.common.option, { count: index + 1 })}
@@ -317,35 +320,79 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
     </Card>
   ) : null;
 
-  const fixedDateCard = savedFinalSlot ? (
+  const statusCard = (
     <Card>
       <CardHeader className="p-4 pb-2">
-        <CardTitle className="text-sm">{messages.common.fixedDate}</CardTitle>
-        <CardDescription className="text-xs">
-          {messages.manageEvent.fixedDatePublishedDescription}
-        </CardDescription>
+        <CardTitle className="text-sm">{messages.manageEvent.eventStatusTitle}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-3 p-4 pt-0">
-        <div className="rounded-md border bg-muted/20 px-3 py-2">
-          <p className="text-sm font-semibold text-foreground">{savedFinalSlot.label}</p>
-          <p className="mt-1 text-[11px] text-muted-foreground">
-            {plural(messages.publicEvent.fullWindowFree, savedFinalSlot.availableCount)}
+        <div className="space-y-2">
+          <Badge
+            variant={snapshot.status === "CLOSED" ? "destructive" : "secondary"}
+            className="h-7 w-fit gap-1.5 px-2.5 text-xs"
+          >
+            {snapshot.status === "CLOSED" ? (
+              <LockIcon className="size-3.5" />
+            ) : (
+              <UnlockIcon className="size-3.5" />
+            )}
+            {snapshot.status === "CLOSED"
+              ? messages.manageEvent.statusClosed
+              : messages.manageEvent.statusOpen}
+          </Badge>
+          <p className="text-sm text-muted-foreground">
+            {snapshot.status === "CLOSED"
+              ? messages.manageEvent.statusClosedDescription
+              : messages.manageEvent.statusOpenDescription}
           </p>
         </div>
-        <Button asChild size="sm" className="w-full">
-          <a href={`/api/events/${snapshot.slug}/ics`}>{messages.common.addToCalendar}</a>
-        </Button>
+
+        {savedFinalSlot ? (
+          <div className="rounded-md border bg-muted/20 px-3 py-2">
+            <p className="text-[11px] font-medium tracking-[0.14em] text-muted-foreground uppercase">
+              {messages.common.fixedDate}
+            </p>
+            <p className="mt-1 text-sm font-semibold text-foreground">{savedFinalSlot.label}</p>
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              {plural(messages.publicEvent.fullWindowFree, savedFinalSlot.availableCount)}
+            </p>
+          </div>
+        ) : null}
+
+        {savedFinalSlot ? (
+          <Button asChild size="sm" className="w-full">
+            <a href={`/api/events/${snapshot.slug}/ics`}>{messages.common.addToCalendar}</a>
+          </Button>
+        ) : null}
+
+        {snapshot.status === "CLOSED" ? (
+          <AlertDialog open={isReopenDialogOpen} onOpenChange={setIsReopenDialogOpen}>
+            <AlertDialogTrigger asChild>
+              <Button type="button" variant="outline" disabled={isPending} className="w-full">
+                {messages.manageEvent.reopenEvent}
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>{messages.manageEvent.reopenEventConfirmTitle}</AlertDialogTitle>
+                <AlertDialogDescription>
+                  {messages.manageEvent.reopenEventConfirmDescription}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>{messages.common.cancel}</AlertDialogCancel>
+                <AlertDialogAction onClick={reopenEvent} disabled={isPending}>
+                  {pendingAction === "reopenEvent" ? (
+                    <Loader2Icon className="size-4 animate-spin" />
+                  ) : null}
+                  {messages.manageEvent.reopenEventConfirmAction}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        ) : null}
       </CardContent>
     </Card>
-  ) : null;
-
-  const sidebarSummaryCards = fixedDateCard ? (
-    <>
-      {fixedDateCard}
-      {bestWindowsCard}
-    </>
-  ) : (
-    bestWindowsCard
   );
 
   const participantsCard = (
@@ -447,8 +494,8 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
           <CardTitle className="text-3xl">{messages.manageEvent.title}</CardTitle>
           <CardDescription>{messages.manageEvent.description}</CardDescription>
         </CardHeader>
-        <CardContent className="grid gap-x-6 gap-y-5 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start">
-          <div className="space-y-2">
+        <CardContent className="pt-0">
+          <div className="max-w-3xl space-y-2">
             <Label htmlFor="title">{messages.manageEvent.titleLabel}</Label>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
               <Input id="title" value={title} onChange={(event) => setTitle(event.target.value)} />
@@ -467,73 +514,13 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
               ) : null}
             </div>
           </div>
-
-          <div className="space-y-3 rounded-xl border bg-muted/15 p-4">
-            <div className="space-y-2">
-              <Label>{messages.manageEvent.statusLabel}</Label>
-              <Badge
-                variant={snapshot.status === "CLOSED" ? "destructive" : "secondary"}
-                className="h-7 w-fit gap-1.5 px-2.5 text-xs"
-              >
-                {snapshot.status === "CLOSED" ? (
-                  <LockIcon className="size-3.5" />
-                ) : (
-                  <UnlockIcon className="size-3.5" />
-                )}
-                {snapshot.status === "CLOSED"
-                  ? messages.manageEvent.statusClosed
-                  : messages.manageEvent.statusOpen}
-              </Badge>
-              <p className="text-sm text-muted-foreground">
-                {snapshot.status === "CLOSED"
-                  ? messages.manageEvent.statusClosedDescription
-                  : messages.manageEvent.statusOpenDescription}
-              </p>
-            </div>
-
-            {savedFinalSlot ? (
-              <div className="rounded-md border bg-background/80 px-3 py-2">
-                <p className="text-[11px] font-medium tracking-[0.14em] text-muted-foreground uppercase">
-                  {messages.common.fixedDate}
-                </p>
-                <p className="mt-1 text-sm font-semibold text-foreground">{savedFinalSlot.label}</p>
-              </div>
-            ) : null}
-
-            {snapshot.status === "CLOSED" ? (
-              <AlertDialog open={isReopenDialogOpen} onOpenChange={setIsReopenDialogOpen}>
-                <AlertDialogTrigger asChild>
-                  <Button type="button" variant="outline" disabled={isPending}>
-                    {messages.manageEvent.reopenEvent}
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>
-                      {messages.manageEvent.reopenEventConfirmTitle}
-                    </AlertDialogTitle>
-                    <AlertDialogDescription>
-                      {messages.manageEvent.reopenEventConfirmDescription}
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>{messages.common.cancel}</AlertDialogCancel>
-                    <AlertDialogAction onClick={reopenEvent} disabled={isPending}>
-                      {pendingAction === "reopenEvent" ? (
-                        <Loader2Icon className="size-4 animate-spin" />
-                      ) : null}
-                      {messages.manageEvent.reopenEventConfirmAction}
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-            ) : null}
-          </div>
         </CardContent>
       </Card>
 
       <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_22rem] xl:items-start">
         <aside className="order-1 min-w-0 space-y-5 xl:order-2">
+          {statusCard}
+
           <Card>
             <CardHeader>
               <CardTitle>{messages.manageEvent.shareLinksTitle}</CardTitle>
@@ -562,7 +549,7 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
             </CardContent>
           </Card>
 
-          {sidebarSummaryCards}
+          {bestWindowsCard}
           {participantsCard}
         </aside>
 
@@ -575,6 +562,8 @@ export function ManageEventClient({ initialView }: ManageEventClientProps) {
             showSidebar={false}
             displayStatus={snapshot.status}
             finalSlotStart={savedFinalSlot?.slotStart ?? null}
+            showStatusBadge={false}
+            showTitleBlock={false}
             showFixedDateAction
             isFixedDateActionPending={
               pendingAction === "closeEvent" || pendingAction === "updateFixedDate"

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -239,6 +239,7 @@ export const en = {
     participantRemoved: "Participant removed",
     titleLabel: "Title",
     saveTitle: "Save title",
+    eventStatusTitle: "Event status",
     statusLabel: "Status",
     statusOpen: "Open for edits",
     statusClosed: "Closed",
@@ -278,13 +279,13 @@ export const en = {
     closeRequiresFixedDateInHeatmap:
       "Pick a fixed date in the heatmap before closing this event.",
     closedHeatmapDescription:
-      "Click any slot to inspect availability and update the published fixed date for this closed event.",
+      "Click a slot to inspect availability and update the published fixed date.",
     closedHeatmapDescriptionWindowed:
-      "Select a slot to inspect overlap and update the fixed date directly below. Use the arrows to move through the date range.",
+      "Select a slot to inspect overlap and update the fixed date below. Use the arrows to move through the date range.",
     openHeatmapDescription:
-      "Click any slot to inspect availability and close the event directly from the slot action.",
+      "Click a slot to inspect availability and close the event from the slot action.",
     openHeatmapDescriptionWindowed:
-      "Select a slot to inspect availability and close the event directly from the slot action. Use the arrows to move through the date range.",
+      "Select a slot to inspect availability and close the event from the slot action. Use the arrows to move through the date range.",
     peopleAvailable: {
       one: "{count} person available",
       other: "{count} people available",
@@ -828,6 +829,7 @@ export const de: Messages = {
     participantRemoved: "Teilnehmende Person entfernt",
     titleLabel: "Titel",
     saveTitle: "Titel speichern",
+    eventStatusTitle: "Eventstatus",
     statusLabel: "Status",
     statusOpen: "Für Änderungen geöffnet",
     statusClosed: "Geschlossen",
@@ -869,13 +871,13 @@ export const de: Messages = {
     closeRequiresFixedDateInHeatmap:
       "Wähle in der Heatmap ein fixes Datum aus, bevor du dieses Event schließt.",
     closedHeatmapDescription:
-      "Klicke auf einen beliebigen Slot, um die Verfügbarkeit zu prüfen und den veröffentlichten fixen Termin für dieses geschlossene Event zu aktualisieren.",
+      "Klicke auf einen Slot, um die Verfügbarkeit zu prüfen und den veröffentlichten fixen Termin zu aktualisieren.",
     closedHeatmapDescriptionWindowed:
-      "Wähle einen Slot aus, um die Überschneidung zu prüfen, und aktualisiere den fixen Termin direkt darunter. Mit den Pfeilen bewegst du dich durch den Datumsbereich.",
+      "Wähle einen Slot aus, um die Überschneidung zu prüfen, und aktualisiere den fixen Termin darunter. Mit den Pfeilen bewegst du dich durch den Datumsbereich.",
     openHeatmapDescription:
-      "Klicke auf einen beliebigen Slot, um die Verfügbarkeit zu prüfen und das Event direkt über die Slot-Aktion zu schließen.",
+      "Klicke auf einen Slot, um die Verfügbarkeit zu prüfen und das Event über die Slot-Aktion zu schließen.",
     openHeatmapDescriptionWindowed:
-      "Wähle einen Slot aus, um die Verfügbarkeit zu prüfen und das Event direkt über die Slot-Aktion zu schließen. Mit den Pfeilen bewegst du dich durch den Datumsbereich.",
+      "Wähle einen Slot aus, um die Verfügbarkeit zu prüfen und das Event über die Slot-Aktion zu schließen. Mit den Pfeilen bewegst du dich durch den Datumsbereich.",
     peopleAvailable: {
       one: "{count} Person verfügbar",
       other: "{count} Personen verfügbar",


### PR DESCRIPTION
## Summary
- replace the draft-heavy organizer close flow with explicit actions for closing, reopening, updating the fixed date, and saving the title independently
- consolidate organizer status and fixed-date controls into a single sidebar summary and remove duplicate status/title surfaces from the manage view heatmap
- add the alert dialog UI primitive and update validation, service, route, i18n, and component coverage for the new organizer actions

## Testing
- `pnpm test:run src/components/manage-event-client.test.tsx src/lib/event-service.test.ts 'src/app/api/manage/[token]/route.test.ts'`
- `pnpm test:run src/components/manage-event-client.test.tsx`
- `pnpm lint`
- `pnpm typecheck`