### PR TITLE
Add env-driven DataFast tracking with token-safe proxy filtering

### DIFF
--- a/.env.coolify.example
+++ b/.env.coolify.example
@@ -2,6 +2,9 @@ APP_SETUP_COMPLETE=false
 APP_NAME=tempoll
 APP_URL=https://tempoll.example.com
 APP_DEFAULT_LOCALE=de
+# Optional DataFast analytics (enabled only if both vars are set):
+DATAFAST_WEBSITE_ID=
+DATAFAST_DOMAIN=
 LEGAL_PAGES_ENABLED=false
 
 TEMPOLL_DB_NAME=tempoll

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ APP_SETUP_COMPLETE=false
 APP_NAME="tempoll"
 APP_URL="http://localhost:3000"
 APP_DEFAULT_LOCALE="de"
+# Optional DataFast analytics (enabled only if both vars are set):
+DATAFAST_WEBSITE_ID=""
+DATAFAST_DOMAIN=""
 DATABASE_URL="postgresql://postgres:postgres@localhost:55432/tempoll?schema=public"
 LEGAL_PAGES_ENABLED=false
 

--- a/README.md
+++ b/README.md
@@ -213,10 +213,29 @@ Health checks stay available at `/api/health`, even while setup is incomplete.
 | `APP_NAME` | Yes | Product name shown in the UI. Defaults to `tempoll`. |
 | `APP_URL` | Yes | Canonical public base URL used for generated links. |
 | `LEGAL_PAGES_ENABLED` | No | Enables `/imprint` and `/privacy`. Defaults to `false`. |
+| `DATAFAST_WEBSITE_ID` | No | Enables optional DataFast tracking when set together with `DATAFAST_DOMAIN`. |
+| `DATAFAST_DOMAIN` | No | Domain sent to DataFast when optional tracking is enabled. |
 | `DATABASE_URL` | Local dev or external DB only | Direct database connection string. |
 | `TEMPOLL_DB_NAME` | Compose/Coolify | Bundled Postgres database name. |
 | `TEMPOLL_DB_USER` | Compose/Coolify | Bundled Postgres database user. |
 | `SERVICE_PASSWORD_TEMPOLL_DB` | Compose/Coolify | Bundled Postgres password secret. Use an underscore, not a hyphen. |
+
+### Optional DataFast analytics (cookieless)
+
+DataFast tracking is disabled by default. It is enabled only when **both** variables are set:
+
+```env
+DATAFAST_WEBSITE_ID=dfid_8DiCXWOXKydljn0usEGZE
+DATAFAST_DOMAIN=tempoll.app
+```
+
+Implementation details in this repository:
+
+- Script source: `https://datafa.st/js/script.cookieless.js`
+- Loaded globally from the root layout via `next/script` (`afterInteractive`)
+- Event endpoint proxied through `POST /api/datafast/events`
+- Organizer routes (`/manage/[token]`) are filtered and not forwarded to DataFast
+- CSP already allows `https://datafa.st` in `script-src` and `connect-src`
 
 ### Optional legal and privacy variables
 
@@ -305,6 +324,7 @@ The cleanup logic in [`src/lib/realtime.ts`](./src/lib/realtime.ts) matters. Clo
 | `POST /api/events/[slug]/participants` | Join an event with a name and establish an edit session |
 | `PUT /api/events/[slug]/availability` | Save availability for the current participant |
 | `GET /api/events/[slug]/stream` | Subscribe to realtime event updates via SSE |
+| `POST /api/datafast/events` | Proxy/filter optional DataFast analytics events |
 | `PATCH /api/manage/[token]` | Update event status/title or rename a participant |
 | `DELETE /api/manage/[token]/participants/[participantId]` | Remove a participant |
 | `GET /api/health` | Health check that remains available before setup completes |

--- a/src/app/api/datafast/events/route.test.ts
+++ b/src/app/api/datafast/events/route.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getClientIp = vi.fn();
+const fetchMock = vi.fn();
+
+vi.mock("@/lib/request", () => ({
+  getClientIp,
+}));
+
+describe("POST /api/datafast/events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getClientIp.mockReturnValue("203.0.113.42");
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("drops events for manage URLs when referer contains /manage/*", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("https://tempoll.example.com/api/datafast/events", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Referer:
+            "https://tempoll.example.com/manage/cmn8tbq86000001pbddo4sxf.a1b2c3d4e5f6",
+        },
+        body: JSON.stringify({
+          pathname: "/manage/cmn8tbq86000001pbddo4sxf.a1b2c3d4e5f6",
+        }),
+      }),
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "success",
+      ignored: true,
+    });
+  });
+
+  it("drops events for manage URLs when referer is missing but payload contains /manage/*", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("https://tempoll.example.com/api/datafast/events", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          pathname: "/manage/cmn8tbq86000001pbddo4sxf.a1b2c3d4e5f6",
+        }),
+      }),
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "success",
+      ignored: true,
+    });
+  });
+
+  it("forwards non-manage events and forwards x-datafast-real-ip", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 202,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+
+    const { POST } = await import("./route");
+    const body = JSON.stringify({
+      pathname: "/e/team-sync",
+    });
+
+    const response = await POST(
+      new Request("https://tempoll.example.com/api/datafast/events", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://tempoll.example.com",
+          Referer: "https://tempoll.example.com/e/team-sync",
+          "User-Agent": "Vitest Agent",
+        },
+        body,
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://datafa.st/api/events",
+      expect.objectContaining({
+        method: "POST",
+        body,
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          Origin: "https://tempoll.example.com",
+          "User-Agent": "Vitest Agent",
+          "x-datafast-real-ip": "203.0.113.42",
+        }),
+      }),
+    );
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+});

--- a/src/app/api/datafast/events/route.ts
+++ b/src/app/api/datafast/events/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server";
+
+import { getClientIp } from "@/lib/request";
+import { PRIVATE_NO_STORE_HEADERS } from "@/lib/security";
+
+const DATAFAST_EVENTS_URL = "https://datafa.st/api/events";
+const MANAGE_PATH_PREFIX = "/manage/";
+const ENCODED_MANAGE_PATH = "%2fmanage%2f";
+
+function getRefererPath(request: Request) {
+  const referer = request.headers.get("referer");
+  if (!referer) {
+    return null;
+  }
+
+  try {
+    return new URL(referer, request.url).pathname;
+  } catch {
+    return null;
+  }
+}
+
+function shouldIgnoreEvent(request: Request, requestBody: string) {
+  const refererPath = getRefererPath(request);
+  if (refererPath?.startsWith(MANAGE_PATH_PREFIX)) {
+    return true;
+  }
+
+  // Manage pages already send Referrer-Policy: no-referrer, so we also inspect payloads.
+  const normalizedBody = requestBody.toLowerCase();
+  return (
+    normalizedBody.includes(MANAGE_PATH_PREFIX) ||
+    normalizedBody.includes(ENCODED_MANAGE_PATH)
+  );
+}
+
+export async function POST(request: Request) {
+  const body = await request.text();
+
+  if (shouldIgnoreEvent(request, body)) {
+    return NextResponse.json(
+      {
+        status: "success",
+        ignored: true,
+      },
+      {
+        headers: PRIVATE_NO_STORE_HEADERS,
+      },
+    );
+  }
+
+  const ip = getClientIp(request);
+  const origin = request.headers.get("origin") ?? new URL(request.url).origin;
+  const contentType = request.headers.get("content-type") ?? "application/json";
+  const userAgent = request.headers.get("user-agent");
+
+  try {
+    const response = await fetch(DATAFAST_EVENTS_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": contentType,
+        Origin: origin,
+        ...(userAgent ? { "User-Agent": userAgent } : {}),
+        "x-datafast-real-ip": ip,
+      },
+      body,
+    });
+
+    const responseBody = await response.text();
+    return new NextResponse(responseBody, {
+      status: response.status,
+      headers: {
+        ...PRIVATE_NO_STORE_HEADERS,
+        "Content-Type": response.headers.get("content-type") ?? "application/json",
+      },
+    });
+  } catch (error) {
+    console.error("[api/datafast/events] Failed to proxy analytics event", error);
+
+    return NextResponse.json(
+      {
+        error: "Failed to forward analytics event.",
+      },
+      {
+        status: 502,
+        headers: PRIVATE_NO_STORE_HEADERS,
+      },
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,10 +2,12 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import type { Metadata } from "next";
 import { Manrope, Space_Grotesk } from "next/font/google";
+import Script from "next/script";
 
 import { AppChrome } from "@/components/app-chrome";
 import { Toaster } from "@/components/ui/sonner";
 import { appConfig } from "@/lib/config";
+import { datafastConfig } from "@/lib/datafast";
 import { I18nProvider } from "@/lib/i18n/context";
 import { getServerI18n } from "@/lib/i18n/server";
 import { buildDefaultMetadata } from "@/lib/site-metadata";
@@ -48,6 +50,16 @@ export default async function RootLayout({
       className={`${bodyFont.variable} ${headingFont.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col bg-background text-foreground">
+        {datafastConfig.enabled ? (
+          <Script
+            id="datafast-tracking"
+            src={datafastConfig.scriptSrc}
+            data-website-id={datafastConfig.websiteId}
+            data-domain={datafastConfig.domain}
+            data-api-url={datafastConfig.apiProxyPath}
+            strategy="afterInteractive"
+          />
+        ) : null}
         <I18nProvider locale={locale} messages={messages}>
           <AppChrome
             appName={appConfig.appName}

--- a/src/lib/datafast.test.ts
+++ b/src/lib/datafast.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const originalWebsiteId = process.env.DATAFAST_WEBSITE_ID;
+const originalDomain = process.env.DATAFAST_DOMAIN;
+
+async function loadConfig() {
+  vi.resetModules();
+  const { datafastConfig } = await import("./datafast");
+  return datafastConfig;
+}
+
+describe("datafast config", () => {
+  afterEach(() => {
+    if (originalWebsiteId === undefined) {
+      delete process.env.DATAFAST_WEBSITE_ID;
+    } else {
+      process.env.DATAFAST_WEBSITE_ID = originalWebsiteId;
+    }
+
+    if (originalDomain === undefined) {
+      delete process.env.DATAFAST_DOMAIN;
+    } else {
+      process.env.DATAFAST_DOMAIN = originalDomain;
+    }
+  });
+
+  it("enables tracking when website id and domain are configured", async () => {
+    process.env.DATAFAST_WEBSITE_ID = "dfid_abc123";
+    process.env.DATAFAST_DOMAIN = "tempoll.app";
+
+    const config = await loadConfig();
+
+    expect(config.enabled).toBe(true);
+    expect(config.websiteId).toBe("dfid_abc123");
+    expect(config.domain).toBe("tempoll.app");
+    expect(config.scriptSrc).toBe("https://datafa.st/js/script.cookieless.js");
+    expect(config.apiProxyPath).toBe("/api/datafast/events");
+  });
+
+  it("disables tracking when website id is missing", async () => {
+    delete process.env.DATAFAST_WEBSITE_ID;
+    process.env.DATAFAST_DOMAIN = "tempoll.app";
+
+    const config = await loadConfig();
+
+    expect(config.enabled).toBe(false);
+    expect(config.websiteId).toBeUndefined();
+    expect(config.domain).toBe("tempoll.app");
+  });
+
+  it("disables tracking when domain is missing", async () => {
+    process.env.DATAFAST_WEBSITE_ID = "dfid_abc123";
+    delete process.env.DATAFAST_DOMAIN;
+
+    const config = await loadConfig();
+
+    expect(config.enabled).toBe(false);
+    expect(config.websiteId).toBe("dfid_abc123");
+    expect(config.domain).toBeUndefined();
+  });
+
+  it("trims configured values", async () => {
+    process.env.DATAFAST_WEBSITE_ID = "  dfid_abc123  ";
+    process.env.DATAFAST_DOMAIN = "  tempoll.app  ";
+
+    const config = await loadConfig();
+
+    expect(config.enabled).toBe(true);
+    expect(config.websiteId).toBe("dfid_abc123");
+    expect(config.domain).toBe("tempoll.app");
+  });
+});

--- a/src/lib/datafast.ts
+++ b/src/lib/datafast.ts
@@ -1,0 +1,18 @@
+const DATAFAST_SCRIPT_SRC = "https://datafa.st/js/script.cookieless.js";
+const DATAFAST_API_PROXY_PATH = "/api/datafast/events";
+
+function getEnv(name: string) {
+  const value = process.env[name]?.trim();
+  return value && value.length > 0 ? value : undefined;
+}
+
+const websiteId = getEnv("DATAFAST_WEBSITE_ID");
+const domain = getEnv("DATAFAST_DOMAIN");
+
+export const datafastConfig = {
+  websiteId,
+  domain,
+  scriptSrc: DATAFAST_SCRIPT_SRC,
+  apiProxyPath: DATAFAST_API_PROXY_PATH,
+  enabled: Boolean(websiteId && domain),
+} as const;

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -463,7 +463,7 @@ export const en = {
     controller: "Controller",
     whatDataIsProcessed: "What data is processed",
     whatDataIsProcessedDescription:
-      "The service is intentionally small and avoids account creation or marketing tracking.",
+      "The service is intentionally small, does not require user accounts, and avoids advertising technologies.",
     purposesAndLegalBases: "Purposes and legal bases",
     cookiesAndLocalStorage: "Cookies and local storage",
     recipientsAndHosting: "Recipients and hosting",
@@ -505,7 +505,7 @@ export const en = {
     cookiesParagraph1:
       "The application uses technically necessary browser storage only. This includes a participant session cookie or equivalent token handling to allow availability editing, and local browser storage for the optional recent-events list on the home page.",
     cookiesParagraph2:
-      "No analytics, advertising, or other non-essential tracking technologies are included in the current version of the app.",
+      "No advertising or third-party marketing trackers are used. If the operator enables optional privacy-friendly analytics, it is limited to product usage measurement.",
     retentionParagraph1:
       "Event data is stored for as long as the controller keeps the corresponding scheduling boards available. Request logs and operational logs are retained only for as long as needed for security, diagnostics, and infrastructure management.",
     retentionParagraph2:
@@ -1077,7 +1077,7 @@ export const de: Messages = {
     controller: "Verantwortliche Stelle",
     whatDataIsProcessed: "Welche Daten verarbeitet werden",
     whatDataIsProcessedDescription:
-      "Der Dienst ist bewusst schlank gehalten und verzichtet auf Konten und Marketing-Tracking.",
+      "Der Dienst ist bewusst schlank gehalten, benötigt keine Benutzerkonten und verzichtet auf Werbetechnologien.",
     purposesAndLegalBases: "Zwecke und Rechtsgrundlagen",
     cookiesAndLocalStorage: "Cookies und lokaler Speicher",
     recipientsAndHosting: "Empfänger und Hosting",
@@ -1121,7 +1121,7 @@ export const de: Messages = {
     cookiesParagraph1:
       "Die Anwendung verwendet ausschließlich technisch notwendige Browser-Speichermechanismen. Dazu gehören ein Sitzungscookie oder eine vergleichbare Token-Verwaltung für die Bearbeitung von Verfügbarkeiten sowie lokaler Browser-Speicher für die optionale Liste zuletzt besuchter Events auf der Startseite.",
     cookiesParagraph2:
-      "In der aktuellen Version der App sind keine Analyse-, Werbe- oder sonstigen nicht erforderlichen Tracking-Technologien enthalten.",
+      "Es werden keine Werbe- oder sonstigen Drittanbieter-Marketing-Tracker eingesetzt. Falls optional datenschutzfreundliche Analytics vom Betreiber aktiviert werden, dienen sie ausschließlich der Nutzungsanalyse des Produkts.",
     retentionParagraph1:
       "Event-Daten werden so lange gespeichert, wie die verantwortliche Stelle die jeweiligen Planungsboards verfügbar hält. Request-Logs und betriebliche Protokolle werden nur so lange aufbewahrt, wie sie für Sicherheit, Diagnose und Infrastrukturverwaltung benötigt werden.",
     retentionParagraph2:

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -22,11 +22,11 @@ export function buildContentSecurityPolicy(options?: {
 
   return [
     "default-src 'self'",
-    `script-src 'self' 'unsafe-inline'${isDevelopment ? " 'unsafe-eval'" : ""}`,
+    `script-src 'self' 'unsafe-inline' https://datafa.st${isDevelopment ? " 'unsafe-eval'" : ""}`,
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob:",
     "font-src 'self' data:",
-    "connect-src 'self'",
+    "connect-src 'self' https://datafa.st",
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",


### PR DESCRIPTION
## Summary
- Add optional, env-driven DataFast configuration via `DATAFAST_WEBSITE_ID` and `DATAFAST_DOMAIN`
- Inject the cookieless DataFast script globally in the root layout using `next/script` with `afterInteractive`
- Route analytics through a first-party endpoint (`POST /api/datafast/events`) and filter out organizer manage URLs (`/manage/[token]`) to avoid leaking private tokens
- Update CSP to allow `https://datafa.st` for both `script-src` and `connect-src`
- Document setup and new API surface in `README`, and add env placeholders in `.env.example` and `.env.coolify.example`
- Adjust privacy copy (EN/DE) to reflect optional privacy-friendly analytics without advertising trackers
- Add tests for DataFast config behavior and proxy route filtering/forwarding

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:run`
- `pnpm build`