### PR TITLE
Fix home metadata title to use default tempoll.app branding

### DIFF
--- a/src/app/page.test.ts
+++ b/src/app/page.test.ts
@@ -20,11 +20,11 @@ describe("Home metadata", () => {
     });
   });
 
-  it("keeps the home copy product-focused and free-to-use", async () => {
+  it("uses the root default title and keeps the home description", async () => {
     const { generateMetadata } = await import("./page");
     const metadata = await generateMetadata();
 
-    expect(metadata.title).toBe("Free scheduling");
+    expect(metadata.title).toBeUndefined();
     expect(metadata.description).toContain("Free scheduling");
     expect(metadata.description).toContain("just a name");
   });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,6 @@ export async function generateMetadata(): Promise<Metadata> {
   const { messages } = await getServerI18n();
 
   return {
-    title: messages.metadata.homeTitle,
     description: messages.metadata.description,
   };
 }


### PR DESCRIPTION
## Summary
- Remove the explicit home page `metadata.title` so the root layout default title is used
- Keep the home metadata description unchanged
- Update the home metadata test to assert that the page-level title is undefined and inherited

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:run src/app/page.test.ts`