### PR TITLE
Fix heatmap rendering mismatch on narrow mobile widths

### DIFF
--- a/src/components/event-heatmap.tsx
+++ b/src/components/event-heatmap.tsx
@@ -1129,7 +1129,8 @@ export function EventHeatmap({
                           return (
                             <div
                               key={`${date.dateKey}-${timeRow.id}`}
-                              className={cn("min-w-[84px] bg-background", cellHeightClass)}
+                              className={cn("bg-background", cellHeightClass)}
+                              style={{ minWidth: `${dayColumnMinWidth}px` }}
                             />
                           );
                         }
@@ -1178,7 +1179,7 @@ export function EventHeatmap({
                             data-final-slot-window={isInFinalSlotWindow ? "true" : undefined}
                             data-final-slot-start={isFinalSlotStart ? "true" : undefined}
                             className={cn(
-                              "min-w-[84px] border-0 transition-colors focus-visible:relative focus-visible:z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
+                              "border-0 transition-colors focus-visible:relative focus-visible:z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
                               cellHeightClass,
                               mode === "edit" && supportsPainting
                                 ? "cursor-crosshair touch-none hover:brightness-[0.98]"
@@ -1190,12 +1191,15 @@ export function EventHeatmap({
                               getActiveViewSelectionClass(isActiveViewSlot),
                               getFinalizedSlotClass(isInFinalSlotWindow),
                             )}
-                            style={getParticipantHighlightStyle({
-                              isHighlighted: isHighlightedParticipantAvailable,
-                              participantColor: activeParticipantId
-                                ? participantColorById.get(activeParticipantId)
-                                : undefined,
-                            })}
+                            style={{
+                              minWidth: `${dayColumnMinWidth}px`,
+                              ...getParticipantHighlightStyle({
+                                isHighlighted: isHighlightedParticipantAvailable,
+                                participantColor: activeParticipantId
+                                  ? participantColorById.get(activeParticipantId)
+                                  : undefined,
+                              }),
+                            }}
                             onPointerDown={(event) =>
                               handleCellPointerDown(
                                 event,


### PR DESCRIPTION
### Motivation
- Narrow/mobile portrait vs landscape showed misaligned or clipped heatmap columns because some cells used a hardcoded `84px` min-width while the grid used a responsive computed day-column width.

### Description
- Apply the computed `dayColumnMinWidth` as inline `minWidth` to empty placeholder cells so they match the grid column sizing.
- Remove the hardcoded `min-w-[84px]` class from interactive slot buttons so buttons use the same responsive min-width as the grid template.
- Preserve participant highlight overlays by merging `getParticipantHighlightStyle(...)` with the responsive `minWidth` in the element `style`.
- All changes are in `src/components/event-heatmap.tsx` and ensure grid template and actual cell widths stay synchronized on narrow screens.

### Testing
- Ran `pnpm lint` and it passed.
- Ran `pnpm typecheck` (`tsc --noEmit`) and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbfc43d6bc8329b60cfa9b372d42af)