### PR TITLE
[codex] Replace invalid brace-expansion security bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
       "@hono/node-server": "1.19.11",
       "effect": "3.21.0",
       "hono": "4.12.9",
-      "lodash": "4.17.23"
+      "lodash": "4.17.23",
+      "minimatch@3>brace-expansion": "1.1.13"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   effect: 3.21.0
   hono: 4.12.9
   lodash: 4.17.23
+  minimatch@3>brace-expansion: 1.1.13
 
 importers:
 
@@ -1820,8 +1821,8 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -6007,7 +6008,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -7409,7 +7410,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.13
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary
- replace the invalid Dependabot bump from PR #30 with a targeted override for `minimatch@3 > brace-expansion`
- update the lockfile so the vulnerable `brace-expansion@1.1.12` path is resolved to `1.1.13`
- keep `minimatch@10` on `brace-expansion@5.0.5` to avoid unnecessary transitive churn or compatibility risk

## Root Cause
Dependabot regenerated `pnpm-lock.yaml`, but the resulting PR did not actually upgrade the vulnerable `brace-expansion@1.1.12` path. The review comments on #30 correctly noted that the advertised security fix was not applied.

## Validation
- `pnpm verify:ci`
- confirmed `pnpm-lock.yaml` resolves `minimatch@3.1.5 -> brace-expansion@1.1.13`
- confirmed `pnpm-lock.yaml` keeps `minimatch@10.2.4 -> brace-expansion@5.0.5`

## Notes
- This PR supersedes #30 because the Dependabot branch is not maintainer-editable.