### PR TITLE
Add Resend digest notifications

### DIFF
--- a/.env.coolify.example
+++ b/.env.coolify.example
@@ -5,6 +5,9 @@ APP_DEFAULT_LOCALE=de
 # Optional DataFast analytics (enabled only if both vars are set):
 DATAFAST_WEBSITE_ID=
 DATAFAST_DOMAIN=
+RESEND_API_KEY=
+RESEND_FROM_EMAIL=
+RESEND_FROM_NAME=tempoll
 LEGAL_PAGES_ENABLED=false
 
 TEMPOLL_DB_NAME=tempoll

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ APP_DEFAULT_LOCALE="de"
 # Optional DataFast analytics (enabled only if both vars are set):
 DATAFAST_WEBSITE_ID=""
 DATAFAST_DOMAIN=""
+RESEND_API_KEY=""
+RESEND_FROM_EMAIL=""
+RESEND_FROM_NAME="tempoll"
 DATABASE_URL="postgresql://postgres:postgres@localhost:55432/tempoll?schema=public"
 LEGAL_PAGES_ENABLED=false
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The project is built for two audiences:
 - No required login. Public participants join with a name only.
 - Private organizer management URL, separate from the public event URL.
 - Realtime collaborative heatmap powered by Postgres `LISTEN/NOTIFY` and Server-Sent Events.
+- Optional Resend-powered organizer digest emails with five-minute quiet-period batching.
 - Ranked best meeting windows based on shared overlap.
 - Date-range based event creation. One range expands into concrete event dates internally.
 - Browser-local recent events history, including private organizer links clearly marked as sensitive.
@@ -227,6 +228,9 @@ Health checks stay available at `/api/health`, even while setup is incomplete.
 | `TEMPOLL_DB_NAME` | Compose/Coolify | Bundled Postgres database name. |
 | `TEMPOLL_DB_USER` | Compose/Coolify | Bundled Postgres database user. |
 | `SERVICE_PASSWORD_TEMPOLL_DB` | Compose/Coolify | Bundled Postgres password secret. Use an underscore, not a hyphen. |
+| `RESEND_API_KEY` | Optional | Enables organizer email digests when set together with `RESEND_FROM_EMAIL`. |
+| `RESEND_FROM_EMAIL` | Optional | Verified sender address for organizer digest emails. |
+| `RESEND_FROM_NAME` | Optional | Friendly sender name for organizer digest emails. Defaults to `tempoll`. |
 
 ### Optional DataFast analytics (cookieless)
 
@@ -244,6 +248,23 @@ Implementation details in this repository:
 - Event endpoint proxied through `POST /api/datafast/events`
 - Organizer routes (`/manage/[token]`) are filtered and not forwarded to DataFast
 - CSP already allows `https://datafa.st` in `script-src` and `connect-src`
+
+### Optional Resend organizer digests
+
+Organizer alert emails are disabled by default. They turn on only when both of these server-side variables are set:
+
+```env
+RESEND_API_KEY=re_...
+RESEND_FROM_EMAIL=notifications@example.com
+RESEND_FROM_NAME=tempoll
+```
+
+Notes for operators:
+
+- `/setup` intentionally does not collect, render, or export any mail secrets.
+- The create flow and organizer manage page expose the email field only when the host is configured for delivery.
+- Availability edits are batched into one digest after five quiet minutes instead of sending on every slot toggle.
+- Digest emails include a private organizer CTA. Treat those inboxes as sensitive.
 
 ### Optional legal and privacy variables
 
@@ -307,6 +328,7 @@ The Prisma schema is intentionally small:
 - Participant editing is tied to an HTTP-only cookie scoped to that event.
 - Recent event history is stored only in the browser, never synced to the server.
 - Organizer URLs are stored locally on purpose and should always be treated as sensitive.
+- Organizer digest emails may include a private manage link, so the recipient mailbox becomes part of that trust boundary.
 
 ### Realtime model
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "date-fns-tz": "^3.2.0",
     "dotenv": "^17.3.1",
     "lucide-react": "^1.7.0",
-    "next": "16.2.1",
+    "next": "16.2.4",
     "next-themes": "^0.4.6",
     "pg": "^8.20.0",
     "react": "19.2.4",
@@ -59,7 +59,7 @@
     "@types/react-dom": "^19",
     "@vitest/ui": "^4.1.1",
     "eslint": "^9",
-    "eslint-config-next": "16.2.1",
+    "eslint-config-next": "16.2.4",
     "jsdom": "^29.0.1",
     "playwright": "^1.58.2",
     "prisma": "^7.5.0",
@@ -70,10 +70,11 @@
   },
   "pnpm": {
     "overrides": {
-      "@hono/node-server": "1.19.11",
+      "@hono/node-server": "1.19.14",
+      "defu": "6.1.7",
       "effect": "3.21.0",
-      "hono": "4.12.9",
-      "lodash": "4.17.23"
+      "hono": "4.12.14",
+      "lodash": "4.18.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react": "19.2.4",
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.4",
+    "resend": "^6.12.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      resend:
+        specifier: ^6.12.0
+        version: 6.12.0
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1302,6 +1305,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2426,6 +2432,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -3487,6 +3496,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
@@ -3691,6 +3703,15 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resend@6.12.0:
+    resolution: {integrity: sha512-CaxEvX1z+/MGbgnhsM/bvmkbnZd1v1sEXELAjBNSDBQNMaB7MgqOyrBgI27CYikEgdaDnBrXghAXYWTBs/h5Bw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3873,6 +3894,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -3977,6 +4001,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.90.0:
+    resolution: {integrity: sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -4162,6 +4189,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
@@ -5475,6 +5506,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
@@ -6754,6 +6787,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.20.1:
@@ -7751,6 +7786,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
@@ -7956,6 +7993,11 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  resend@6.12.0:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.90.0
 
   resolve-from@4.0.0: {}
 
@@ -8246,6 +8288,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
@@ -8361,6 +8408,11 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.90.0:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
 
   symbol-tree@3.2.4: {}
 
@@ -8562,6 +8614,8 @@ snapshots:
       '@types/react': 19.2.14
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,11 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@hono/node-server': 1.19.11
+  '@hono/node-server': 1.19.14
+  defu: 6.1.7
   effect: 3.21.0
-  hono: 4.12.9
-  lodash: 4.17.23
+  hono: 4.12.14
+  lodash: 4.18.1
 
 importers:
 
@@ -57,8 +58,8 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0(react@19.2.4)
       next:
-        specifier: 16.2.1
-        version: 16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 16.2.4
+        version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -121,8 +122,8 @@ importers:
         specifier: ^9
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
-        specifier: 16.2.1
-        version: 16.2.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        specifier: 16.2.4
+        version: 16.2.4(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1(@noble/hashes@1.8.0)
@@ -448,11 +449,11 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.9
+      hono: 4.12.14
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -698,60 +699,60 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
-  '@next/env@16.2.1':
-    resolution: {integrity: sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==}
+  '@next/env@16.2.4':
+    resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
 
-  '@next/eslint-plugin-next@16.2.1':
-    resolution: {integrity: sha512-r0epZGo24eT4g08jJlg2OEryBphXqO8aL18oajoTKLzHJ6jVr6P6FI58DLMug04MwD3j8Fj0YK0slyzneKVyzA==}
+  '@next/eslint-plugin-next@16.2.4':
+    resolution: {integrity: sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA==}
 
-  '@next/swc-darwin-arm64@16.2.1':
-    resolution: {integrity: sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q==}
+  '@next/swc-darwin-arm64@16.2.4':
+    resolution: {integrity: sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.1':
-    resolution: {integrity: sha512-/vrcE6iQSJq3uL3VGVHiXeaKbn8Es10DGTGRJnRZlkNQQk3kaNtAJg8Y6xuAlrx/6INKVjkfi5rY0iEXorZ6uA==}
+  '@next/swc-darwin-x64@16.2.4':
+    resolution: {integrity: sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.1':
-    resolution: {integrity: sha512-uLn+0BK+C31LTVbQ/QU+UaVrV0rRSJQ8RfniQAHPghDdgE+SlroYqcmFnO5iNjNfVWCyKZHYrs3Nl0mUzWxbBw==}
+  '@next/swc-linux-arm64-gnu@16.2.4':
+    resolution: {integrity: sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.1':
-    resolution: {integrity: sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==}
+  '@next/swc-linux-arm64-musl@16.2.4':
+    resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.1':
-    resolution: {integrity: sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==}
+  '@next/swc-linux-x64-gnu@16.2.4':
+    resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.1':
-    resolution: {integrity: sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==}
+  '@next/swc-linux-x64-musl@16.2.4':
+    resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.1':
-    resolution: {integrity: sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==}
+  '@next/swc-win32-arm64-msvc@16.2.4':
+    resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.1':
-    resolution: {integrity: sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg==}
+  '@next/swc-win32-x64-msvc@16.2.4':
+    resolution: {integrity: sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2104,8 +2105,8 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
@@ -2246,8 +2247,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@16.2.1:
-    resolution: {integrity: sha512-qhabwjQZ1Mk53XzXvmogf8KQ0tG0CQXF0CZ56+2/lVhmObgmaqj7x5A1DSrWdZd3kwI7GTPGUjFne+krRxYmFg==}
+  eslint-config-next@16.2.4:
+    resolution: {integrity: sha512-A6ekXYFj/YQxBPMl45g3e+U8zJo+X2+ZQwcz34pPKjpc/3S4roBA2Rd9xWB4FKuSxhofo1/95WjzmUY+wHrOhg==}
     peerDependencies:
       eslint: '>=9.0.0'
       typescript: '>=3.3.1'
@@ -2664,8 +2665,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.12.9:
-    resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -3088,8 +3089,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
@@ -3233,8 +3234,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.2.1:
-    resolution: {integrity: sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q==}
+  next@16.2.4:
+    resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -4636,12 +4637,12 @@ snapshots:
     dependencies:
       '@chevrotain/gast': 10.5.0
       '@chevrotain/types': 10.5.0
-      lodash: 4.17.23
+      lodash: 4.18.1
 
   '@chevrotain/gast@10.5.0':
     dependencies:
       '@chevrotain/types': 10.5.0
-      lodash: 4.17.23
+      lodash: 4.18.1
 
   '@chevrotain/types@10.5.0': {}
 
@@ -4782,9 +4783,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@hono/node-server@1.19.11(hono@4.12.9)':
+  '@hono/node-server@1.19.14(hono@4.12.14)':
     dependencies:
-      hono: 4.12.9
+      hono: 4.12.14
 
   '@humanfs/core@0.19.1': {}
 
@@ -4943,7 +4944,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.28.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.11(hono@4.12.9)
+      '@hono/node-server': 1.19.14(hono@4.12.14)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4953,7 +4954,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.9
+      hono: 4.12.14
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -4991,34 +4992,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@16.2.1': {}
+  '@next/env@16.2.4': {}
 
-  '@next/eslint-plugin-next@16.2.1':
+  '@next/eslint-plugin-next@16.2.4':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.2.1':
+  '@next/swc-darwin-arm64@16.2.4':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.1':
+  '@next/swc-darwin-x64@16.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.1':
+  '@next/swc-linux-arm64-gnu@16.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.1':
+  '@next/swc-linux-arm64-musl@16.2.4':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.1':
+  '@next/swc-linux-x64-gnu@16.2.4':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.1':
+  '@next/swc-linux-x64-musl@16.2.4':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.1':
+  '@next/swc-win32-arm64-msvc@16.2.4':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.1':
+  '@next/swc-win32-x64-msvc@16.2.4':
     optional: true
 
   '@noble/ciphers@1.3.0': {}
@@ -5092,13 +5093,13 @@ snapshots:
       '@electric-sql/pglite': 0.3.15
       '@electric-sql/pglite-socket': 0.0.20(@electric-sql/pglite@0.3.15)
       '@electric-sql/pglite-tools': 0.2.20(@electric-sql/pglite@0.3.15)
-      '@hono/node-server': 1.19.11(hono@4.12.9)
+      '@hono/node-server': 1.19.14(hono@4.12.14)
       '@mrleebo/prisma-ast': 0.13.1
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       foreground-child: 3.3.1
       get-port-please: 3.2.0
-      hono: 4.12.9
+      hono: 4.12.14
       http-status-codes: 2.3.0
       pathe: 2.0.3
       proper-lockfile: 4.1.2
@@ -6071,7 +6072,7 @@ snapshots:
     dependencies:
       chokidar: 4.0.3
       confbox: 0.2.4
-      defu: 6.1.4
+      defu: 6.1.7
       dotenv: 16.6.1
       exsolve: 1.0.8
       giget: 2.0.0
@@ -6118,7 +6119,7 @@ snapshots:
       '@chevrotain/gast': 10.5.0
       '@chevrotain/types': 10.5.0
       '@chevrotain/utils': 10.5.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       regexp-to-ast: 0.5.0
 
   chokidar@4.0.3:
@@ -6290,7 +6291,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  defu@6.1.4: {}
+  defu@6.1.7: {}
 
   denque@2.1.0: {}
 
@@ -6473,9 +6474,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.2.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.2.4(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@next/eslint-plugin-next': 16.2.1
+      '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
@@ -6944,7 +6945,7 @@ snapshots:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       node-fetch-native: 1.6.7
       nypm: 0.6.5
       pathe: 2.0.3
@@ -7006,7 +7007,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.12.9: {}
+  hono@4.12.14: {}
 
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
@@ -7378,7 +7379,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   log-symbols@6.0.0:
     dependencies:
@@ -7508,9 +7509,9 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@next/env': 16.2.1
+      '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.10
       caniuse-lite: 1.0.30001781
@@ -7519,14 +7520,14 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.1
-      '@next/swc-darwin-x64': 16.2.1
-      '@next/swc-linux-arm64-gnu': 16.2.1
-      '@next/swc-linux-arm64-musl': 16.2.1
-      '@next/swc-linux-x64-gnu': 16.2.1
-      '@next/swc-linux-x64-musl': 16.2.1
-      '@next/swc-win32-arm64-msvc': 16.2.1
-      '@next/swc-win32-x64-msvc': 16.2.1
+      '@next/swc-darwin-arm64': 16.2.4
+      '@next/swc-darwin-x64': 16.2.4
+      '@next/swc-linux-arm64-gnu': 16.2.4
+      '@next/swc-linux-arm64-musl': 16.2.4
+      '@next/swc-linux-x64-gnu': 16.2.4
+      '@next/swc-linux-x64-musl': 16.2.4
+      '@next/swc-win32-arm64-msvc': 16.2.4
+      '@next/swc-win32-x64-msvc': 16.2.4
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -7902,7 +7903,7 @@ snapshots:
 
   rc9@2.1.2:
     dependencies:
-      defu: 6.1.4
+      defu: 6.1.7
       destr: 2.0.5
 
   react-day-picker@9.14.0(react@19.2.4):

--- a/prisma/migrations/20260417113000_add_availability_notifications/migration.sql
+++ b/prisma/migrations/20260417113000_add_availability_notifications/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "EventAvailabilityNotification" (
+    "eventId" TEXT NOT NULL,
+    "recipientEmail" TEXT,
+    "emailManageTokenHash" TEXT,
+    "pendingSinceAt" TIMESTAMP(3),
+    "pendingFlushAfterAt" TIMESTAMP(3),
+    "pendingParticipantIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "pendingChangeCount" INTEGER NOT NULL DEFAULT 0,
+    "lastSentAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EventAvailabilityNotification_pkey" PRIMARY KEY ("eventId")
+);
+
+-- CreateIndex
+CREATE INDEX "EventAvailabilityNotification_pendingFlushAfterAt_idx" ON "EventAvailabilityNotification"("pendingFlushAfterAt");
+
+-- AddForeignKey
+ALTER TABLE "EventAvailabilityNotification" ADD CONSTRAINT "EventAvailabilityNotification_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model Event {
   dates                  EventDate[]
   participants           Participant[]
   availabilitySlots      AvailabilitySlot[]
+  availabilityNotification EventAvailabilityNotification?
 }
 
 model EventDate {
@@ -68,4 +69,20 @@ model AvailabilitySlot {
 
   @@id([participantId, slotStartAt])
   @@index([eventId, slotStartAt])
+}
+
+model EventAvailabilityNotification {
+  eventId              String   @id
+  recipientEmail       String?
+  emailManageTokenHash String?
+  pendingSinceAt       DateTime?
+  pendingFlushAfterAt  DateTime?
+  pendingParticipantIds String[] @default([])
+  pendingChangeCount   Int      @default(0)
+  lastSentAt           DateTime?
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+  event                Event    @relation(fields: [eventId], references: [id], onDelete: Cascade)
+
+  @@index([pendingFlushAfterAt])
 }

--- a/src/app/api/events/route.test.ts
+++ b/src/app/api/events/route.test.ts
@@ -22,6 +22,45 @@ describe("POST /api/events", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getClientIp.mockReturnValue("127.0.0.1");
+    createEvent.mockResolvedValue({
+      slug: "sprint-planning",
+      manageKey: "manage-key-123",
+    });
+  });
+
+  it("passes the optional notification email through to event creation", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("https://tempoll.example.com/api/events", {
+        method: "POST",
+        body: JSON.stringify({
+          title: "Sprint Planning",
+          timezone: "Europe/Vienna",
+          dates: ["2026-03-30"],
+          dayStartMinutes: 540,
+          dayEndMinutes: 600,
+          slotMinutes: 30,
+          meetingDurationMinutes: 60,
+          notificationEmail: "owner@example.com",
+        }),
+        headers: {
+          "Accept-Language": "en-US",
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+
+    expect(createEvent).toHaveBeenCalledWith({
+      title: "Sprint Planning",
+      timezone: "Europe/Vienna",
+      dates: ["2026-03-30"],
+      dayStartMinutes: 540,
+      dayEndMinutes: 600,
+      slotMinutes: 30,
+      meetingDurationMinutes: 60,
+      notificationEmail: "owner@example.com",
+    });
+    expect(response.status).toBe(201);
   });
 
   it("returns a 429 with Retry-After when the create-event limit is exceeded", async () => {

--- a/src/app/api/manage/[token]/route.test.ts
+++ b/src/app/api/manage/[token]/route.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { notFound } from "@/lib/errors";
+import { notFound, serviceUnavailable } from "@/lib/errors";
 
 const updateManagedEvent = vi.fn();
 const getClientIp = vi.fn();
@@ -22,6 +22,51 @@ describe("PATCH /api/manage/[token]", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getClientIp.mockReturnValue("127.0.0.1");
+    updateManagedEvent.mockResolvedValue({});
+  });
+
+  it("returns the updated notification payload for organizer email alerts", async () => {
+    updateManagedEvent.mockResolvedValue({
+      notification: {
+        isConfigured: true,
+        recipientEmail: "owner@example.com",
+        quietPeriodMinutes: 5,
+        lastSentAt: null,
+        pendingDigest: null,
+      },
+    });
+
+    const { PATCH } = await import("./route");
+    const response = await PATCH(
+      new Request("https://tempoll.example.com/api/manage/private-token", {
+        method: "PATCH",
+        body: JSON.stringify({
+          action: "updateNotificationEmail",
+          notificationEmail: "owner@example.com",
+        }),
+        headers: {
+          "Accept-Language": "en-US",
+          "Content-Type": "application/json",
+        },
+      }),
+      {
+        params: Promise.resolve({
+          token: "private-token",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      notification: {
+        isConfigured: true,
+        recipientEmail: "owner@example.com",
+        quietPeriodMinutes: 5,
+        lastSentAt: null,
+        pendingDigest: null,
+      },
+    });
   });
 
   it("returns 404 for invalid organizer tokens without leaking internal details", async () => {
@@ -80,6 +125,35 @@ describe("PATCH /api/manage/[token]", () => {
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({
       error: "Unable to update event.",
+    });
+  });
+
+  it("returns a localized 503 when email delivery is unavailable on the host", async () => {
+    updateManagedEvent.mockRejectedValue(serviceUnavailable("notification_delivery_unavailable"));
+
+    const { PATCH } = await import("./route");
+    const response = await PATCH(
+      new Request("https://tempoll.example.com/api/manage/private-token", {
+        method: "PATCH",
+        body: JSON.stringify({
+          action: "updateNotificationEmail",
+          notificationEmail: "owner@example.com",
+        }),
+        headers: {
+          "Accept-Language": "en-US",
+          "Content-Type": "application/json",
+        },
+      }),
+      {
+        params: Promise.resolve({
+          token: "private-token",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "Email alerts are not available on this host.",
     });
   });
 });

--- a/src/app/api/manage/[token]/route.ts
+++ b/src/app/api/manage/[token]/route.ts
@@ -29,10 +29,10 @@ export async function PATCH(request: Request, { params }: Context) {
     const json = await request.json();
     const input = createManageUpdateSchema(i18n.messages).parse(json);
 
-    await updateManagedEvent(token, input);
+    const result = await updateManagedEvent(token, input);
 
     return NextResponse.json(
-      { ok: true },
+      { ok: true, ...result },
       {
         headers: MANAGE_RESPONSE_HEADERS,
       },

--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 
 import { CreateEventForm } from "@/components/create-event-form";
 import { buildTimeOptions } from "@/lib/availability";
+import { isNotificationDeliveryConfigured } from "@/lib/config";
 import { getSupportedTimezones } from "@/lib/constants";
 import { getServerI18n } from "@/lib/i18n/server";
 
@@ -31,6 +32,7 @@ export default async function NewEventPage() {
       <CreateEventForm
         timezones={getSupportedTimezones()}
         timeOptions={buildTimeOptions(30)}
+        notificationsConfigured={isNotificationDeliveryConfigured()}
       />
     </main>
   );

--- a/src/components/create-event-form.test.tsx
+++ b/src/components/create-event-form.test.tsx
@@ -30,9 +30,16 @@ const defaultTimeOptions = [
   { value: 24 * 60, label: "24:00" },
 ];
 
-function renderCreateEventForm(locale: AppLocale = "en") {
+function renderCreateEventForm(
+  locale: AppLocale = "en",
+  { notificationsConfigured = true }: { notificationsConfigured?: boolean } = {},
+) {
   return renderWithI18n(
-    <CreateEventForm timezones={defaultTimezones} timeOptions={defaultTimeOptions} />,
+    <CreateEventForm
+      timezones={defaultTimezones}
+      timeOptions={defaultTimeOptions}
+      notificationsConfigured={notificationsConfigured}
+    />,
     { locale },
   );
 }
@@ -124,6 +131,7 @@ describe("CreateEventForm", () => {
       <CreateEventForm
         timezones={["Europe/Vienna", "America/New_York", "UTC"]}
         timeOptions={defaultTimeOptions}
+        notificationsConfigured={true}
       />,
     );
 
@@ -181,6 +189,43 @@ describe("CreateEventForm", () => {
       dayEndMinutes: 17 * 60,
       slotMinutes: 15,
     });
+  });
+
+  it("submits the optional notification email when alerts are available", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        manageKey: "manage-key-123",
+      }),
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    renderCreateEventForm();
+
+    await user.type(screen.getByLabelText("Event title"), "Sprint planning");
+    await user.type(screen.getByLabelText("Organizer email alerts"), "owner@example.com");
+    await user.click(screen.getByRole("button", { name: "Create event" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const payload = JSON.parse(String(requestInit.body)) as {
+      notificationEmail?: string;
+    };
+
+    expect(payload.notificationEmail).toBe("owner@example.com");
+  });
+
+  it("shows an unavailable note instead of the email field when alerts are disabled", () => {
+    renderCreateEventForm("en", {
+      notificationsConfigured: false,
+    });
+
+    expect(screen.queryByLabelText("Organizer email alerts")).not.toBeInTheDocument();
+    expect(screen.getByText("Email alerts are not available on this host yet.")).toBeInTheDocument();
   });
 
   it("offers meeting durations up to 6 hours", async () => {

--- a/src/components/create-event-form.tsx
+++ b/src/components/create-event-form.tsx
@@ -42,10 +42,12 @@ type CreateEventFormProps = {
     value: number;
     label: string;
   }>;
+  notificationsConfigured: boolean;
 };
 
 const eventFieldOrder = [
   "title",
+  "notificationEmail",
   "timezone",
   "dates",
   "dayStartMinutes",
@@ -59,6 +61,7 @@ type EventFormErrors = Partial<Record<EventField, string>>;
 
 const eventFieldIds: Record<EventField, string> = {
   title: "title",
+  notificationEmail: "notification-email",
   timezone: "timezone-trigger",
   dates: "date-range-trigger",
   dayStartMinutes: "day-start-trigger",
@@ -100,7 +103,11 @@ function getRangeDays(range: DateRange | undefined) {
   }).length;
 }
 
-export function CreateEventForm({ timezones, timeOptions }: CreateEventFormProps) {
+export function CreateEventForm({
+  timezones,
+  timeOptions,
+  notificationsConfigured,
+}: CreateEventFormProps) {
   const router = useRouter();
   const { messages, plural, format: formatMessage, dateFnsLocale, locale } = useI18n();
   const [isPending, startTransition] = useTransition();
@@ -108,6 +115,7 @@ export function CreateEventForm({ timezones, timeOptions }: CreateEventFormProps
   const [fieldErrors, setFieldErrors] = useState<EventFormErrors>({});
   const [isRangePickerOpen, setIsRangePickerOpen] = useState(false);
   const [title, setTitle] = useState("");
+  const [notificationEmail, setNotificationEmail] = useState("");
   const [dateRange, setDateRange] = useState<DateRange | undefined>(() => {
     const tomorrow = addDays(new Date(), 1);
     return {
@@ -261,6 +269,7 @@ export function CreateEventForm({ timezones, timeOptions }: CreateEventFormProps
 
     const parsed = createEventCreateSchema(messages).safeParse({
       title,
+      notificationEmail: notificationsConfigured ? notificationEmail : undefined,
       timezone,
       dates: selectedDates,
       dayStartMinutes,
@@ -340,6 +349,46 @@ export function CreateEventForm({ timezones, timeOptions }: CreateEventFormProps
                 </p>
               ) : null}
             </div>
+
+            {notificationsConfigured ? (
+              <div className="space-y-2">
+                <Label htmlFor={eventFieldIds.notificationEmail}>
+                  {messages.createEvent.notificationEmailLabel}
+                </Label>
+                <p className="text-sm text-muted-foreground">
+                  {messages.createEvent.notificationEmailDescription}
+                </p>
+                <Input
+                  id={eventFieldIds.notificationEmail}
+                  type="email"
+                  inputMode="email"
+                  autoComplete="email"
+                  placeholder={messages.createEvent.notificationEmailPlaceholder}
+                  value={notificationEmail}
+                  aria-invalid={fieldErrors.notificationEmail ? true : undefined}
+                  aria-describedby={
+                    fieldErrors.notificationEmail ? "notification-email-error" : undefined
+                  }
+                  className={cn(
+                    fieldErrors.notificationEmail &&
+                      "border-destructive focus-visible:ring-destructive/20",
+                  )}
+                  onChange={(event) => {
+                    setNotificationEmail(event.target.value);
+                    clearErrors("notificationEmail");
+                  }}
+                />
+                {fieldErrors.notificationEmail ? (
+                  <p id="notification-email-error" className="text-sm text-destructive">
+                    {fieldErrors.notificationEmail}
+                  </p>
+                ) : null}
+              </div>
+            ) : (
+              <div className="rounded-md border bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
+                {messages.createEvent.notificationEmailUnavailable}
+              </div>
+            )}
 
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div className="space-y-2">

--- a/src/components/manage-event-client.test.tsx
+++ b/src/components/manage-event-client.test.tsx
@@ -29,15 +29,29 @@ vi.mock("sonner", () => ({
 function createManageView(options?: {
   status?: "OPEN" | "CLOSED";
   finalizedSlot?: ManageEventView["snapshot"]["finalizedSlot"];
+  recipientEmail?: string | null;
+  notificationsConfigured?: boolean;
 }): ManageEventView {
   const status = options?.status ?? "OPEN";
   const finalizedSlot = options?.finalizedSlot ?? null;
+  const recipientEmail =
+    options && "recipientEmail" in options ? options.recipientEmail ?? null : "owner@example.com";
 
   return {
     manageKey: "cmn8tbq86000001pbddo4sxf.a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
     shareUrl: "https://tempoll.app/e/test-event-xeqlxw",
     manageUrl:
       "https://tempoll.app/manage/cmn8tbq86000001pbddo4sxf.a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
+    notification: {
+      isConfigured: options?.notificationsConfigured ?? true,
+      recipientEmail,
+      quietPeriodMinutes: 5,
+      lastSentAt: "2026-04-01T08:00:00.000Z",
+      pendingDigest: {
+        participantCount: 2,
+        flushAfterAt: "2026-04-02T07:35:00.000Z",
+      },
+    },
     snapshot: {
       id: "event_1",
       slug: "test-event-xeqlxw",
@@ -138,6 +152,7 @@ function buildPublishedFinalizedSlot(
 
 function installManageFetchMock(view: ManageEventView) {
   let currentSnapshot = structuredClone(view.snapshot) as PublicEventSnapshot;
+  let currentNotification = structuredClone(view.notification);
   const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
 
@@ -155,7 +170,8 @@ function installManageFetchMock(view: ManageEventView) {
         | { action: "updateTitle"; title: string }
         | { action: "closeEvent"; finalSlotStart: string }
         | { action: "updateFixedDate"; finalSlotStart: string }
-        | { action: "reopenEvent" };
+        | { action: "reopenEvent" }
+        | { action: "updateNotificationEmail"; notificationEmail?: string };
 
       switch (payload.action) {
         case "updateTitle":
@@ -179,11 +195,18 @@ function installManageFetchMock(view: ManageEventView) {
             finalizedSlot: null,
           };
           break;
+        case "updateNotificationEmail":
+          currentNotification = {
+            ...currentNotification,
+            recipientEmail: payload.notificationEmail?.trim().toLowerCase() || null,
+            pendingDigest: payload.notificationEmail ? currentNotification.pendingDigest : null,
+          };
+          break;
       }
 
       return {
         ok: true,
-        json: async () => ({ ok: true }),
+        json: async () => ({ ok: true, notification: currentNotification }),
       };
     }
 
@@ -216,6 +239,7 @@ describe("ManageEventClient", () => {
 
     const eventStatusHeading = screen.getByText("Event status");
     const shareLinksHeading = screen.getByText("Share links");
+    const emailAlertsHeading = screen.getByText("Email alerts");
     const bestWindowsHeading = screen.getByText("Best windows right now");
     const participantsHeading = screen.getByText("Participants");
     const availabilityHeading = screen.getByText("Availability");
@@ -227,6 +251,10 @@ describe("ManageEventClient", () => {
     ).toBeTruthy();
     expect(
       shareLinksHeading.compareDocumentPosition(availabilityHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      emailAlertsHeading.compareDocumentPosition(availabilityHeading) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
@@ -416,6 +444,49 @@ describe("ManageEventClient", () => {
       action: "updateTitle",
       title: "Updated team sync",
     });
+  });
+
+  it("shows email alert scheduling details in the organizer sidebar", () => {
+    const view = createManageView();
+    renderWithI18n(<ManageEventClient initialView={view} />);
+
+    expect(screen.getByText("Email alerts")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("owner@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Each email includes a fresh private organizer link. Treat it as sensitive.")).toBeInTheDocument();
+  });
+
+  it("saves the organizer notification email without refreshing the snapshot", async () => {
+    const user = userEvent.setup();
+    const view = createManageView({
+      recipientEmail: null,
+    });
+    const fetchMock = installManageFetchMock(view);
+    renderWithI18n(<ManageEventClient initialView={view} />);
+
+    const input = screen.getByLabelText("Send alerts to");
+    await user.type(input, "owner@example.com");
+    await user.click(screen.getByRole("button", { name: "Save email" }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Send alerts to")).toHaveValue("owner@example.com");
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(requestInit.body))).toMatchObject({
+      action: "updateNotificationEmail",
+      notificationEmail: "owner@example.com",
+    });
+  });
+
+  it("shows an unavailable note when email alerts are disabled on the host", () => {
+    const view = createManageView({
+      notificationsConfigured: false,
+      recipientEmail: null,
+    });
+    renderWithI18n(<ManageEventClient initialView={view} />);
+
+    expect(screen.getByText("Email alerts are not available on this host right now.")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Send alerts to")).not.toBeInTheDocument();
   });
 
   it("shows the saved fixed date with an .ics export link", () => {

--- a/src/components/manage-event-client.tsx
+++ b/src/components/manage-event-client.tsx
@@ -126,11 +126,11 @@ export function ManageEventClient({
   );
   const notificationTimestampFormatter = useMemo(
     () =>
-      new Intl.DateTimeFormat(undefined, {
+      new Intl.DateTimeFormat(locale, {
         dateStyle: "medium",
         timeStyle: "short",
       }),
-    [],
+    [locale],
   );
   const pendingDigestSummary = notification.pendingDigest
     ? format(messages.manageEvent.emailAlertsPending, {

--- a/src/components/manage-event-client.tsx
+++ b/src/components/manage-event-client.tsx
@@ -26,7 +26,11 @@ import { Label } from "@/components/ui/label";
 import { formatMeetingWindowLabels } from "@/lib/availability";
 import { useI18n } from "@/lib/i18n/context";
 import { buildTimezoneOptions } from "@/lib/timezone-options";
-import type { ManageEventView, PublicEventSnapshot } from "@/lib/types";
+import type {
+  ManageEventNotificationState,
+  ManageEventView,
+  PublicEventSnapshot,
+} from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useViewerTimezone } from "@/lib/viewer-timezone";
 
@@ -41,7 +45,8 @@ type PendingAction =
   | "updateFixedDate"
   | "reopenEvent"
   | "renameParticipant"
-  | "removeParticipant";
+  | "removeParticipant"
+  | "updateNotificationEmail";
 
 type RefreshSnapshotOptions = {
   preserveDirtyTitle?: boolean;
@@ -53,6 +58,12 @@ export function ManageEventClient({
 }: ManageEventClientProps) {
   const { messages, format, plural, locale } = useI18n();
   const [snapshot, setSnapshot] = useState<PublicEventSnapshot>(initialView.snapshot);
+  const [notification, setNotification] = useState<ManageEventNotificationState>(
+    initialView.notification,
+  );
+  const [notificationEmail, setNotificationEmail] = useState(
+    initialView.notification.recipientEmail ?? "",
+  );
   const [title, setTitle] = useState(initialView.snapshot.title);
   const [requestedActiveParticipantId, setRequestedActiveParticipantId] = useState<string | null>(
     null,
@@ -72,6 +83,9 @@ export function ManageEventClient({
   );
   const savedFinalSlot = snapshot.status === "CLOSED" ? snapshot.finalizedSlot : null;
   const isTitleDirty = title !== snapshot.title;
+  const normalizedNotificationEmail = notificationEmail.trim().toLowerCase();
+  const isNotificationEmailDirty =
+    normalizedNotificationEmail !== (notification.recipientEmail ?? "");
   const manageActionUrl = `/api/manage/${initialView.manageKey}`;
   const visibleSuggestions = savedFinalSlot
     ? snapshot.suggestions.filter((suggestion) => suggestion.slotStart !== savedFinalSlot.slotStart)
@@ -110,6 +124,26 @@ export function ManageEventClient({
       })),
     [locale, viewerTimezone, visibleSuggestions],
   );
+  const notificationTimestampFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }),
+    [],
+  );
+  const pendingDigestSummary = notification.pendingDigest
+    ? format(messages.manageEvent.emailAlertsPending, {
+        timestamp: notificationTimestampFormatter.format(
+          new Date(notification.pendingDigest.flushAfterAt),
+        ),
+      })
+    : messages.manageEvent.emailAlertsIdle;
+  const lastSentSummary = notification.lastSentAt
+    ? format(messages.manageEvent.emailAlertsLastSent, {
+        timestamp: notificationTimestampFormatter.format(new Date(notification.lastSentAt)),
+      })
+    : null;
 
   const refreshSnapshot = useCallback(
     async ({ preserveDirtyTitle = false }: RefreshSnapshotOptions = {}) => {
@@ -151,7 +185,10 @@ export function ManageEventClient({
       successMessage: string;
       errorMessage: string;
       preserveDirtyTitleOnRefresh?: boolean;
-      onSuccess?: () => Promise<void> | void;
+      onSuccess?: (payload: {
+        error?: string;
+        notification?: ManageEventNotificationState;
+      }) => Promise<void> | void;
     },
   ) {
     setPendingAction(action);
@@ -159,7 +196,10 @@ export function ManageEventClient({
     startTransition(async () => {
       try {
         const response = await request();
-        const payload = (await response.json()) as { error?: string };
+        const payload = (await response.json()) as {
+          error?: string;
+          notification?: ManageEventNotificationState;
+        };
         if (!response.ok) {
           toast.error(payload.error ?? errorMessage);
           return;
@@ -168,7 +208,7 @@ export function ManageEventClient({
         toast.success(successMessage);
 
         if (onSuccess) {
-          await onSuccess();
+          await onSuccess(payload);
           return;
         }
 
@@ -330,6 +370,37 @@ export function ManageEventClient({
           await refreshSnapshot({
             preserveDirtyTitle: true,
           });
+        },
+      },
+    );
+  }
+
+  function saveNotificationEmail(nextEmail = notificationEmail) {
+    performManageAction(
+      "updateNotificationEmail",
+      () =>
+        fetch(manageActionUrl, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            action: "updateNotificationEmail",
+            notificationEmail: nextEmail,
+          }),
+        }),
+      {
+        successMessage: nextEmail.trim()
+          ? messages.manageEvent.notificationEmailSaved
+          : messages.manageEvent.notificationEmailCleared,
+        errorMessage: messages.errors.routeFallbacks.updateEvent,
+        onSuccess: (payload) => {
+          if (!payload.notification) {
+            return;
+          }
+
+          setNotification(payload.notification);
+          setNotificationEmail(payload.notification.recipientEmail ?? "");
         },
       },
     );
@@ -588,6 +659,64 @@ export function ManageEventClient({
                 </div>
                 <CopyButton value={initialView.manageUrl} label={messages.manageEvent.copyOrganizerUrl} />
               </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{messages.manageEvent.emailAlertsTitle}</CardTitle>
+              <CardDescription>{messages.manageEvent.emailAlertsDescription}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {notification.isConfigured ? (
+                <>
+                  <div className="space-y-2">
+                    <Label htmlFor="notification-email">
+                      {messages.manageEvent.emailAlertsRecipientLabel}
+                    </Label>
+                    <Input
+                      id="notification-email"
+                      type="email"
+                      inputMode="email"
+                      autoComplete="email"
+                      value={notificationEmail}
+                      placeholder={messages.createEvent.notificationEmailPlaceholder}
+                      onChange={(event) => setNotificationEmail(event.target.value)}
+                    />
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      type="button"
+                      onClick={() => saveNotificationEmail()}
+                      disabled={isPending || !isNotificationEmailDirty}
+                    >
+                      {pendingAction === "updateNotificationEmail" ? (
+                        <Loader2Icon className="size-4 animate-spin" />
+                      ) : null}
+                      {messages.manageEvent.emailAlertsSave}
+                    </Button>
+                    {notification.recipientEmail ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => saveNotificationEmail("")}
+                        disabled={isPending}
+                      >
+                        {messages.manageEvent.emailAlertsClear}
+                      </Button>
+                    ) : null}
+                  </div>
+                  <div className="rounded-md border bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
+                    <p>{pendingDigestSummary}</p>
+                    {lastSentSummary ? <p className="mt-2">{lastSentSummary}</p> : null}
+                    <p className="mt-2">{messages.manageEvent.emailAlertsPrivateLinkNote}</p>
+                  </div>
+                </>
+              ) : (
+                <div className="rounded-md border bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
+                  {messages.manageEvent.emailAlertsUnavailable}
+                </div>
+              )}
             </CardContent>
           </Card>
 

--- a/src/lib/availability-notifications.test.tsx
+++ b/src/lib/availability-notifications.test.tsx
@@ -23,6 +23,47 @@ function cloneNotification(notification: NotificationRecord | null) {
   return notification ? structuredClone(notification) : null;
 }
 
+function notificationMatchesWhere(
+  notification: NotificationRecord,
+  where: Record<string, unknown>,
+) {
+  return Object.entries(where).every(([key, value]) => {
+    const currentValue = (notification as Record<string, unknown>)[key];
+
+    if (currentValue instanceof Date && value instanceof Date) {
+      return currentValue.getTime() === value.getTime();
+    }
+
+    return currentValue === value;
+  });
+}
+
+function applyNotificationUpdate(
+  notification: NotificationRecord,
+  data: Record<string, unknown>,
+) {
+  const next: NotificationRecord = {
+    ...notification,
+    updatedAt: new Date(),
+  };
+
+  for (const [key, value] of Object.entries(data)) {
+    if (key === "pendingParticipantIds" && value && typeof value === "object" && "set" in value) {
+      next.pendingParticipantIds = [...((value as { set: string[] }).set ?? [])];
+      continue;
+    }
+
+    if (key === "pendingChangeCount" && value && typeof value === "object" && "increment" in value) {
+      next.pendingChangeCount += Number((value as { increment?: number }).increment ?? 0);
+      continue;
+    }
+
+    (next as Record<string, unknown>)[key] = value;
+  }
+
+  return next;
+}
+
 function createBaseEvent() {
   return {
     id: "event_1",
@@ -134,29 +175,32 @@ const prisma = {
           throw new Error(`Missing notification ${where.eventId}`);
         }
 
-        const next: NotificationRecord = {
-          ...existing,
-          updatedAt: new Date(),
-        };
-
-        for (const [key, value] of Object.entries(data)) {
-          if (key === "pendingParticipantIds" && value && typeof value === "object" && "set" in value) {
-            next.pendingParticipantIds = [...((value as { set: string[] }).set ?? [])];
-            continue;
-          }
-
-          if (key === "pendingChangeCount" && value && typeof value === "object" && "increment" in value) {
-            next.pendingChangeCount += Number(
-              (value as { increment?: number }).increment ?? 0,
-            );
-            continue;
-          }
-
-          (next as Record<string, unknown>)[key] = value;
-        }
+        const next = applyNotificationUpdate(existing, data);
 
         store.notifications.set(where.eventId, next);
         return cloneNotification(next);
+      },
+    ),
+    updateMany: vi.fn(
+      async ({
+        where,
+        data,
+      }: {
+        where: Record<string, unknown>;
+        data: Record<string, unknown>;
+      }) => {
+        let count = 0;
+
+        for (const [eventId, notification] of store.notifications.entries()) {
+          if (!notificationMatchesWhere(notification, where)) {
+            continue;
+          }
+
+          store.notifications.set(eventId, applyNotificationUpdate(notification, data));
+          count += 1;
+        }
+
+        return { count };
       },
     ),
   },
@@ -361,5 +405,86 @@ describe("availability notifications", () => {
     await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
 
     expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("keeps newer pending changes when another edit lands during digest delivery", async () => {
+    sendEmail.mockImplementationOnce(async () => {
+      const notification = store.notifications.get("event_1");
+      if (!notification) {
+        throw new Error("Missing notification");
+      }
+
+      store.notifications.set("event_1", {
+        ...notification,
+        pendingFlushAfterAt: new Date("2026-04-01T09:10:00.000Z"),
+        pendingParticipantIds: ["participant_1", "participant_2"],
+        pendingChangeCount: 2,
+        updatedAt: new Date("2026-04-01T09:05:00.000Z"),
+      });
+
+      return {
+        data: {
+          id: "email_3",
+        },
+        error: null,
+      };
+    });
+
+    const { queueAvailabilityDigest } = await import("./availability-notifications");
+
+    await queueAvailabilityDigest({
+      eventId: "event_1",
+      participantId: "participant_1",
+      recipientEmail: "owner@example.com",
+    });
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(store.notifications.get("event_1")?.pendingFlushAfterAt).toEqual(
+      new Date("2026-04-01T09:10:00.000Z"),
+    );
+    expect(store.notifications.get("event_1")?.pendingParticipantIds).toEqual([
+      "participant_1",
+      "participant_2",
+    ]);
+    expect(store.notifications.get("event_1")?.pendingChangeCount).toBe(2);
+    expect(store.notifications.get("event_1")?.lastSentAt).toBeInstanceOf(Date);
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
+
+    expect(sendEmail).toHaveBeenCalledTimes(2);
+    expect(store.notifications.get("event_1")?.pendingFlushAfterAt).toBeNull();
+    expect(store.notifications.get("event_1")?.pendingChangeCount).toBe(0);
+  });
+
+  it("invalidates the previously emailed organizer token when the recipient changes", async () => {
+    store.notifications.set("event_1", {
+      eventId: "event_1",
+      recipientEmail: "owner@example.com",
+      emailManageTokenHash: "previous-email-token-hash",
+      pendingSinceAt: new Date("2026-04-01T09:00:00.000Z"),
+      pendingFlushAfterAt: new Date("2026-04-01T09:05:00.000Z"),
+      pendingParticipantIds: ["participant_1"],
+      pendingChangeCount: 1,
+      lastSentAt: null,
+      createdAt: new Date("2026-04-01T09:00:00.000Z"),
+      updatedAt: new Date("2026-04-01T09:00:00.000Z"),
+    });
+
+    const { updateNotificationRecipient } = await import("./availability-notifications");
+
+    const notification = await updateNotificationRecipient("event_1", "new-owner@example.com");
+
+    expect(store.notifications.get("event_1")?.recipientEmail).toBe("new-owner@example.com");
+    expect(store.notifications.get("event_1")?.emailManageTokenHash).toBeNull();
+    expect(store.notifications.get("event_1")?.pendingFlushAfterAt).toEqual(
+      new Date("2026-04-01T09:05:00.000Z"),
+    );
+    expect(notification.recipientEmail).toBe("new-owner@example.com");
+    expect(notification.pendingDigest).toEqual({
+      participantCount: 1,
+      flushAfterAt: "2026-04-01T09:05:00.000Z",
+    });
   });
 });

--- a/src/lib/availability-notifications.test.tsx
+++ b/src/lib/availability-notifications.test.tsx
@@ -145,6 +145,13 @@ const prisma = {
             continue;
           }
 
+          if (key === "pendingChangeCount" && value && typeof value === "object" && "increment" in value) {
+            next.pendingChangeCount += Number(
+              (value as { increment?: number }).increment ?? 0,
+            );
+            continue;
+          }
+
           (next as Record<string, unknown>)[key] = value;
         }
 
@@ -158,6 +165,11 @@ const prisma = {
       where.id === "event_1" ? getEventWithNotification() : null,
     ),
   },
+  $transaction: vi.fn(
+    async (
+      callback: (tx: typeof prisma) => Promise<unknown>,
+    ) => callback(prisma),
+  ),
 };
 
 vi.mock("@/lib/prisma", () => ({
@@ -316,5 +328,38 @@ describe("availability notifications", () => {
     expect(sendEmail).toHaveBeenCalledTimes(2);
     expect(store.notifications.get("event_1")?.pendingFlushAfterAt).toBeNull();
     expect(store.notifications.get("event_1")?.lastSentAt).toBeInstanceOf(Date);
+  });
+
+  it("does not restore a cleared recipient email from a stale availability save", async () => {
+    store.notifications.set("event_1", {
+      eventId: "event_1",
+      recipientEmail: null,
+      emailManageTokenHash: null,
+      pendingSinceAt: null,
+      pendingFlushAfterAt: null,
+      pendingParticipantIds: [],
+      pendingChangeCount: 0,
+      lastSentAt: null,
+      createdAt: new Date("2026-04-01T09:00:00.000Z"),
+      updatedAt: new Date("2026-04-01T09:00:00.000Z"),
+    });
+
+    const { queueAvailabilityDigest } = await import("./availability-notifications");
+
+    await queueAvailabilityDigest({
+      eventId: "event_1",
+      participantId: "participant_1",
+      recipientEmail: "stale@example.com",
+    });
+
+    const notification = store.notifications.get("event_1");
+    expect(notification?.recipientEmail).toBeNull();
+    expect(notification?.pendingFlushAfterAt).toBeNull();
+    expect(notification?.pendingParticipantIds).toEqual([]);
+    expect(notification?.pendingChangeCount).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
+
+    expect(sendEmail).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/availability-notifications.test.tsx
+++ b/src/lib/availability-notifications.test.tsx
@@ -1,0 +1,320 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendEmail = vi.hoisted(() => vi.fn());
+
+type NotificationRecord = {
+  eventId: string;
+  recipientEmail: string | null;
+  emailManageTokenHash: string | null;
+  pendingSinceAt: Date | null;
+  pendingFlushAfterAt: Date | null;
+  pendingParticipantIds: string[];
+  pendingChangeCount: number;
+  lastSentAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const store = {
+  notifications: new Map<string, NotificationRecord>(),
+};
+
+function cloneNotification(notification: NotificationRecord | null) {
+  return notification ? structuredClone(notification) : null;
+}
+
+function createBaseEvent() {
+  return {
+    id: "event_1",
+    slug: "team-sync",
+    title: "Team Sync",
+    timezone: "Europe/Vienna",
+    slotMinutes: 30,
+    meetingDurationMinutes: 60,
+    dayStartMinutes: 9 * 60,
+    dayEndMinutes: 11 * 60,
+    status: "OPEN" as const,
+    finalSlotStartAt: null,
+    manageTokenHash: "hashed-manage-token",
+    createdAt: new Date("2026-04-01T08:00:00.000Z"),
+    updatedAt: new Date("2026-04-01T08:00:00.000Z"),
+    dates: [
+      {
+        id: "date_1",
+        eventId: "event_1",
+        dateKey: "2026-04-02",
+        createdAt: new Date("2026-04-01T08:00:00.000Z"),
+      },
+    ],
+    participants: [
+      {
+        id: "participant_1",
+        eventId: "event_1",
+        displayName: "Felix",
+        displayNameNormalized: "felix",
+        color: "#ef7f3b",
+        editTokenHash: "hash-1",
+        lastSeenAt: null,
+        createdAt: new Date("2026-04-01T08:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T08:00:00.000Z"),
+        availabilitySlots: [
+          {
+            slotStartAt: new Date("2026-04-02T07:00:00.000Z"),
+          },
+          {
+            slotStartAt: new Date("2026-04-02T07:30:00.000Z"),
+          },
+        ],
+      },
+      {
+        id: "participant_2",
+        eventId: "event_1",
+        displayName: "Nora",
+        displayNameNormalized: "nora",
+        color: "#6b8afd",
+        editTokenHash: "hash-2",
+        lastSeenAt: null,
+        createdAt: new Date("2026-04-01T08:02:00.000Z"),
+        updatedAt: new Date("2026-04-01T08:02:00.000Z"),
+        availabilitySlots: [
+          {
+            slotStartAt: new Date("2026-04-02T07:00:00.000Z"),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function getEventWithNotification() {
+  const event = createBaseEvent();
+
+  return {
+    ...event,
+    availabilityNotification: cloneNotification(store.notifications.get(event.id) ?? null),
+  };
+}
+
+const prisma = {
+  eventAvailabilityNotification: {
+    findUnique: vi.fn(async ({ where }: { where: { eventId: string } }) =>
+      cloneNotification(store.notifications.get(where.eventId) ?? null),
+    ),
+    findMany: vi.fn(async () =>
+      Array.from(store.notifications.values())
+        .filter((notification) => notification.recipientEmail && notification.pendingFlushAfterAt)
+        .map((notification) => cloneNotification(notification)),
+    ),
+    create: vi.fn(async ({ data }: { data: Partial<NotificationRecord> & { eventId: string } }) => {
+      const notification: NotificationRecord = {
+        eventId: data.eventId,
+        recipientEmail: data.recipientEmail ?? null,
+        emailManageTokenHash: data.emailManageTokenHash ?? null,
+        pendingSinceAt: data.pendingSinceAt ?? null,
+        pendingFlushAfterAt: data.pendingFlushAfterAt ?? null,
+        pendingParticipantIds: data.pendingParticipantIds ?? [],
+        pendingChangeCount: data.pendingChangeCount ?? 0,
+        lastSentAt: data.lastSentAt ?? null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      store.notifications.set(notification.eventId, notification);
+      return cloneNotification(notification);
+    }),
+    update: vi.fn(
+      async ({
+        where,
+        data,
+      }: {
+        where: { eventId: string };
+        data: Record<string, unknown>;
+      }) => {
+        const existing = store.notifications.get(where.eventId);
+        if (!existing) {
+          throw new Error(`Missing notification ${where.eventId}`);
+        }
+
+        const next: NotificationRecord = {
+          ...existing,
+          updatedAt: new Date(),
+        };
+
+        for (const [key, value] of Object.entries(data)) {
+          if (key === "pendingParticipantIds" && value && typeof value === "object" && "set" in value) {
+            next.pendingParticipantIds = [...((value as { set: string[] }).set ?? [])];
+            continue;
+          }
+
+          (next as Record<string, unknown>)[key] = value;
+        }
+
+        store.notifications.set(where.eventId, next);
+        return cloneNotification(next);
+      },
+    ),
+  },
+  event: {
+    findUnique: vi.fn(async ({ where }: { where: { id: string } }) =>
+      where.id === "event_1" ? getEventWithNotification() : null,
+    ),
+  },
+};
+
+vi.mock("@/lib/prisma", () => ({
+  prisma,
+}));
+
+vi.mock("resend", () => ({
+  Resend: class MockResend {
+    emails = {
+      send: sendEmail,
+    };
+  },
+}));
+
+describe("availability notifications", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T09:00:00.000Z"));
+    store.notifications.clear();
+    sendEmail.mockReset();
+    sendEmail.mockResolvedValue({
+      data: {
+        id: "email_1",
+      },
+      error: null,
+    });
+    process.env.APP_NAME = "tempoll";
+    process.env.APP_URL = "https://tempoll.app";
+    process.env.APP_DEFAULT_LOCALE = "en";
+    process.env.RESEND_API_KEY = "re_test";
+    process.env.RESEND_FROM_EMAIL = "alerts@tempoll.app";
+    process.env.RESEND_FROM_NAME = "tempoll";
+  });
+
+  afterEach(async () => {
+    const { resetAvailabilityNotificationsForTests } = await import("./availability-notifications");
+    resetAvailabilityNotificationsForTests();
+    vi.useRealTimers();
+  });
+
+  it("renders digest content with private and public calls to action", async () => {
+    store.notifications.set("event_1", {
+      eventId: "event_1",
+      recipientEmail: "owner@example.com",
+      emailManageTokenHash: null,
+      pendingSinceAt: new Date("2026-04-01T09:00:00.000Z"),
+      pendingFlushAfterAt: new Date("2026-04-01T09:05:00.000Z"),
+      pendingParticipantIds: ["participant_1", "participant_2"],
+      pendingChangeCount: 2,
+      lastSentAt: null,
+      createdAt: new Date("2026-04-01T09:00:00.000Z"),
+      updatedAt: new Date("2026-04-01T09:00:00.000Z"),
+    });
+
+    const { buildAvailabilityDigestEmail } = await import("./availability-notifications");
+    const event = getEventWithNotification();
+    const email = await buildAvailabilityDigestEmail(event as never);
+
+    expect(email.subject).toContain("tempoll");
+    expect(email.subject).toContain("Team Sync");
+    expect(email.html).toContain("Open private organizer link");
+    expect(email.html).toContain("https://tempoll.app/e/team-sync");
+    expect(email.html).toContain("Felix");
+    expect(email.html).toContain("Nora");
+    expect(email.html).toMatch(/https:\/\/tempoll\.app\/manage\/event_1\.[A-Za-z0-9_-]+/);
+    expect(email.text).toContain("Private organizer link");
+  });
+
+  it("sends one digest after the quiet period", async () => {
+    const {
+      queueAvailabilityDigest,
+      resetAvailabilityNotificationsForTests,
+    } = await import("./availability-notifications");
+
+    await queueAvailabilityDigest({
+      eventId: "event_1",
+      participantId: "participant_1",
+      recipientEmail: "owner@example.com",
+    });
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    const notification = store.notifications.get("event_1");
+    expect(notification?.pendingFlushAfterAt).toBeNull();
+    expect(notification?.pendingChangeCount).toBe(0);
+    expect(notification?.lastSentAt).toBeInstanceOf(Date);
+
+    resetAvailabilityNotificationsForTests();
+  });
+
+  it("extends the quiet period and combines participant changes across edits", async () => {
+    const { queueAvailabilityDigest } = await import("./availability-notifications");
+
+    await queueAvailabilityDigest({
+      eventId: "event_1",
+      participantId: "participant_1",
+      recipientEmail: "owner@example.com",
+    });
+
+    await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
+
+    await queueAvailabilityDigest({
+      eventId: "event_1",
+      participantId: "participant_2",
+      recipientEmail: "owner@example.com",
+    });
+
+    await vi.advanceTimersByTimeAsync(60 * 1000);
+    expect(sendEmail).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(4 * 60 * 1000 + 1);
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    const payload = sendEmail.mock.calls[0]?.[0] as {
+      subject: string;
+      html: string;
+    };
+    expect(payload.subject).toContain("2 people updated Team Sync");
+    expect(payload.html).toContain("Felix");
+    expect(payload.html).toContain("Nora");
+  });
+
+  it("retries a digest after a send failure", async () => {
+    sendEmail
+      .mockResolvedValueOnce({
+        data: null,
+        error: {
+          message: "Resend is unavailable",
+        },
+      })
+      .mockResolvedValue({
+        data: {
+          id: "email_2",
+        },
+        error: null,
+      });
+
+    const { queueAvailabilityDigest } = await import("./availability-notifications");
+
+    await queueAvailabilityDigest({
+      eventId: "event_1",
+      participantId: "participant_1",
+      recipientEmail: "owner@example.com",
+    });
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(store.notifications.get("event_1")?.pendingFlushAfterAt).toBeInstanceOf(Date);
+    expect(store.notifications.get("event_1")?.lastSentAt).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
+
+    expect(sendEmail).toHaveBeenCalledTimes(2);
+    expect(store.notifications.get("event_1")?.pendingFlushAfterAt).toBeNull();
+    expect(store.notifications.get("event_1")?.lastSentAt).toBeInstanceOf(Date);
+  });
+});

--- a/src/lib/availability-notifications.tsx
+++ b/src/lib/availability-notifications.tsx
@@ -535,34 +535,48 @@ async function flushAvailabilityDigest(eventId: string) {
   }
 
   const event = await getEventForDigest(eventId);
-  if (!event?.availabilityNotification?.recipientEmail || !event.availabilityNotification.pendingFlushAfterAt) {
+  const notification = event?.availabilityNotification;
+
+  if (!event || !notification?.recipientEmail || !notification.pendingFlushAfterAt) {
     clearDigestTimer(eventId);
     return;
   }
 
-  if (event.availabilityNotification.pendingFlushAfterAt.getTime() > Date.now()) {
-    scheduleDigestTimer(eventId, event.availabilityNotification.pendingFlushAfterAt);
+  if (notification.pendingFlushAfterAt.getTime() > Date.now()) {
+    scheduleDigestTimer(eventId, notification.pendingFlushAfterAt);
     return;
   }
 
   const { rawEmailManageToken, subject, html, text } = await buildAvailabilityDigestEmail(event);
-  const previousEmailManageTokenHash = event.availabilityNotification.emailManageTokenHash;
+  const previousEmailManageTokenHash = notification.emailManageTokenHash;
   const emailManageTokenHash = hashSecret(rawEmailManageToken);
+  const digestRecipientEmail = notification.recipientEmail;
+  const digestPendingFlushAfterAt = notification.pendingFlushAfterAt;
+  const digestPendingChangeCount = notification.pendingChangeCount;
 
-  await prisma.eventAvailabilityNotification.update({
+  const claimResult = await prisma.eventAvailabilityNotification.updateMany({
     where: {
       eventId,
+      recipientEmail: digestRecipientEmail,
+      emailManageTokenHash: previousEmailManageTokenHash,
+      pendingFlushAfterAt: digestPendingFlushAfterAt,
+      pendingChangeCount: digestPendingChangeCount,
     },
     data: {
       emailManageTokenHash,
     },
   });
 
+  if (claimResult.count === 0) {
+    await reschedulePendingDigest(eventId);
+    return;
+  }
+
   try {
     const resend = getResendClient();
     const sendResult = await resend.emails.send({
       from: `${notificationConfig.resendFromName ?? appConfig.appName} <${notificationConfig.resendFromEmail!}>`,
-      to: [event.availabilityNotification.recipientEmail],
+      to: [digestRecipientEmail],
       subject,
       html,
       text,
@@ -576,12 +590,17 @@ async function flushAvailabilityDigest(eventId: string) {
       );
     }
 
-    await prisma.eventAvailabilityNotification.update({
+    const digestSentAt = new Date();
+    const clearResult = await prisma.eventAvailabilityNotification.updateMany({
       where: {
         eventId,
+        recipientEmail: digestRecipientEmail,
+        emailManageTokenHash,
+        pendingFlushAfterAt: digestPendingFlushAfterAt,
+        pendingChangeCount: digestPendingChangeCount,
       },
       data: {
-        lastSentAt: new Date(),
+        lastSentAt: digestSentAt,
         pendingSinceAt: null,
         pendingFlushAfterAt: null,
         pendingParticipantIds: {
@@ -590,12 +609,30 @@ async function flushAvailabilityDigest(eventId: string) {
         pendingChangeCount: 0,
       },
     });
+
+    if (clearResult.count === 0) {
+      await prisma.eventAvailabilityNotification.updateMany({
+        where: {
+          eventId,
+        },
+        data: {
+          lastSentAt: digestSentAt,
+        },
+      });
+
+      await reschedulePendingDigest(eventId);
+      return;
+    }
   } catch (error) {
     const nextFlushAfterAt = new Date(Date.now() + DIGEST_QUIET_PERIOD_MS);
 
-    await prisma.eventAvailabilityNotification.update({
+    const retryResult = await prisma.eventAvailabilityNotification.updateMany({
       where: {
         eventId,
+        recipientEmail: digestRecipientEmail,
+        emailManageTokenHash,
+        pendingFlushAfterAt: digestPendingFlushAfterAt,
+        pendingChangeCount: digestPendingChangeCount,
       },
       data: {
         emailManageTokenHash: previousEmailManageTokenHash,
@@ -603,7 +640,12 @@ async function flushAvailabilityDigest(eventId: string) {
       },
     });
 
-    scheduleDigestTimer(eventId, nextFlushAfterAt);
+    if (retryResult.count > 0) {
+      scheduleDigestTimer(eventId, nextFlushAfterAt);
+    } else {
+      await reschedulePendingDigest(eventId);
+    }
+
     console.error("[availability-notifications] Failed to send digest", error);
     return;
   }
@@ -802,16 +844,20 @@ export async function updateNotificationRecipient(eventId: string, notificationE
     },
     select: {
       eventId: true,
+      recipientEmail: true,
     },
   });
 
   if (existing) {
+    const recipientEmailChanged = existing.recipientEmail !== recipientEmail;
+
     await prisma.eventAvailabilityNotification.update({
       where: {
         eventId,
       },
       data: {
         recipientEmail,
+        emailManageTokenHash: recipientEmailChanged ? null : undefined,
       },
     });
   } else {

--- a/src/lib/availability-notifications.tsx
+++ b/src/lib/availability-notifications.tsx
@@ -1,0 +1,855 @@
+import { Prisma } from "@prisma/client";
+import { Resend } from "resend";
+
+import { buildSnapshot } from "@/lib/availability";
+import { appConfig, isNotificationDeliveryConfigured, notificationConfig } from "@/lib/config";
+import { serviceUnavailable } from "@/lib/errors";
+import { getIntlLocale } from "@/lib/i18n/format";
+import { prisma } from "@/lib/prisma";
+import { buildManageKey, buildManageUrl, buildPublicEventUrl, createOpaqueToken, hashSecret } from "@/lib/tokens";
+import type { AppLocale } from "@/lib/i18n/locale";
+import type { ManageEventNotificationState } from "@/lib/types";
+
+const DIGEST_QUIET_PERIOD_MINUTES = notificationConfig.quietPeriodMinutes;
+const DIGEST_QUIET_PERIOD_MS = DIGEST_QUIET_PERIOD_MINUTES * 60 * 1000;
+
+type NotificationRow = {
+  recipientEmail: string | null;
+  pendingFlushAfterAt: Date | null;
+  pendingParticipantIds: string[];
+  lastSentAt: Date | null;
+};
+
+type NotificationEvent = Prisma.EventGetPayload<{
+  include: {
+    dates: {
+      orderBy: {
+        dateKey: "asc";
+      };
+    };
+    participants: {
+      orderBy: {
+        createdAt: "asc";
+      };
+      include: {
+        availabilitySlots: {
+          select: {
+            slotStartAt: true;
+          };
+        };
+      };
+    };
+    availabilityNotification: true;
+  };
+}>;
+
+const globalForAvailabilityNotifications = globalThis as unknown as {
+  availabilityDigestTimers?: Map<string, ReturnType<typeof setTimeout>>;
+  availabilityDigestRecoveryPromise?: Promise<void>;
+  availabilityDigestRecovered?: boolean;
+  availabilityDigestResend?: Resend;
+};
+
+function getDigestTimers() {
+  if (!globalForAvailabilityNotifications.availabilityDigestTimers) {
+    globalForAvailabilityNotifications.availabilityDigestTimers = new Map();
+  }
+
+  return globalForAvailabilityNotifications.availabilityDigestTimers;
+}
+
+function normalizeNotificationEmail(email?: string | null) {
+  const trimmed = email?.trim().toLowerCase();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+function getNotificationLocale(): AppLocale {
+  return appConfig.defaultLocale;
+}
+
+function getResendClient() {
+  if (!isNotificationDeliveryConfigured()) {
+    throw serviceUnavailable("notification_delivery_unavailable");
+  }
+
+  if (!globalForAvailabilityNotifications.availabilityDigestResend) {
+    globalForAvailabilityNotifications.availabilityDigestResend = new Resend(
+      notificationConfig.resendApiKey!,
+    );
+  }
+
+  return globalForAvailabilityNotifications.availabilityDigestResend;
+}
+
+function clearDigestTimer(eventId: string) {
+  const timer = getDigestTimers().get(eventId);
+  if (timer) {
+    clearTimeout(timer);
+    getDigestTimers().delete(eventId);
+  }
+}
+
+function scheduleDigestTimer(eventId: string, flushAfterAt: Date) {
+  if (!isNotificationDeliveryConfigured()) {
+    return;
+  }
+
+  clearDigestTimer(eventId);
+
+  const delayMs = Math.max(0, flushAfterAt.getTime() - Date.now());
+  const handle = setTimeout(() => {
+    getDigestTimers().delete(eventId);
+    void flushAvailabilityDigest(eventId);
+  }, delayMs);
+
+  (handle as ReturnType<typeof setTimeout> & { unref?: () => void }).unref?.();
+
+  getDigestTimers().set(eventId, handle);
+}
+
+function getNotificationQuery() {
+  return {
+    dates: {
+      orderBy: {
+        dateKey: "asc" as const,
+      },
+    },
+    participants: {
+      orderBy: {
+        createdAt: "asc" as const,
+      },
+      include: {
+        availabilitySlots: {
+          select: {
+            slotStartAt: true,
+          },
+        },
+      },
+    },
+    availabilityNotification: true,
+  };
+}
+
+async function getEventForDigest(eventId: string) {
+  return prisma.event.findUnique({
+    where: {
+      id: eventId,
+    },
+    include: getNotificationQuery(),
+  });
+}
+
+function buildNotificationSnapshot(event: NotificationEvent) {
+  const locale = getNotificationLocale();
+
+  return buildSnapshot({
+    id: event.id,
+    slug: event.slug,
+    title: event.title,
+    locale,
+    timezone: event.timezone,
+    status: event.status,
+    slotMinutes: event.slotMinutes,
+    meetingDurationMinutes: event.meetingDurationMinutes,
+    dayStartMinutes: event.dayStartMinutes,
+    dayEndMinutes: event.dayEndMinutes,
+    dates: event.dates.map((date) => date.dateKey),
+    participants: event.participants.map((participant) => ({
+      id: participant.id,
+      displayName: participant.displayName,
+      color: participant.color,
+      availabilitySlotStarts: participant.availabilitySlots.map((slot) => slot.slotStartAt.toISOString()),
+    })),
+    finalSlotStart: event.finalSlotStartAt?.toISOString() ?? null,
+  });
+}
+
+function formatNotificationDate(value: Date | string, timezone: string, locale: AppLocale) {
+  return new Intl.DateTimeFormat(getIntlLocale(locale), {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: timezone,
+  }).format(new Date(value));
+}
+
+function formatChangedParticipants(participants: string[]) {
+  if (participants.length === 0) {
+    return "A participant";
+  }
+
+  if (participants.length === 1) {
+    return participants[0];
+  }
+
+  if (participants.length === 2) {
+    return `${participants[0]} and ${participants[1]}`;
+  }
+
+  return `${participants[0]}, ${participants[1]}, and ${participants.length - 2} more`;
+}
+
+function buildDigestSubject(eventTitle: string, participantNames: string[]) {
+  if (participantNames.length === 0) {
+    return `${appConfig.appName}: Availability changed on ${eventTitle}`;
+  }
+
+  if (participantNames.length === 1) {
+    return `${appConfig.appName}: ${participantNames[0]} updated ${eventTitle}`;
+  }
+
+  return `${appConfig.appName}: ${participantNames.length} people updated ${eventTitle}`;
+}
+
+function AvailabilityDigestEmail({
+  changedParticipants,
+  currentBestWindows,
+  eventTitle,
+  eventTimezone,
+  finalizedSlotLabel,
+  manageUrl,
+  publicUrl,
+}: {
+  changedParticipants: string[];
+  currentBestWindows: string[];
+  eventTitle: string;
+  eventTimezone: string;
+  finalizedSlotLabel: string | null;
+  manageUrl: string;
+  publicUrl: string;
+}) {
+  const changedSummary = formatChangedParticipants(changedParticipants);
+  const pageBackground = "#f4faf9";
+  const cardBackground = "#ffffff";
+  const accent = "#0e8690";
+  const muted = "#5f7281";
+  const strong = "#163848";
+
+  return (
+    <html>
+      <body
+        style={{
+          margin: 0,
+          backgroundColor: pageBackground,
+          color: strong,
+          fontFamily:
+            '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        }}
+      >
+        <div style={{ padding: "32px 16px" }}>
+          <div
+            style={{
+              maxWidth: "640px",
+              margin: "0 auto",
+              backgroundColor: cardBackground,
+              borderRadius: "18px",
+              overflow: "hidden",
+              boxShadow: "0 18px 60px rgba(22, 56, 72, 0.12)",
+              border: "1px solid rgba(14, 134, 144, 0.12)",
+            }}
+          >
+            <div
+              style={{
+                padding: "28px 32px",
+                background:
+                  "linear-gradient(135deg, rgba(14, 134, 144, 0.96), rgba(16, 112, 126, 0.92))",
+                color: "#ffffff",
+              }}
+            >
+              <div
+                style={{
+                  display: "inline-block",
+                  padding: "6px 10px",
+                  borderRadius: "999px",
+                  backgroundColor: "rgba(255, 255, 255, 0.14)",
+                  fontSize: "12px",
+                  fontWeight: 700,
+                  letterSpacing: "0.08em",
+                  textTransform: "uppercase",
+                }}
+              >
+                {appConfig.appName}
+              </div>
+              <h1
+                style={{
+                  margin: "18px 0 8px",
+                  fontSize: "30px",
+                  lineHeight: 1.15,
+                }}
+              >
+                Availability changed on {eventTitle}
+              </h1>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: "16px",
+                  lineHeight: 1.6,
+                  color: "rgba(255, 255, 255, 0.9)",
+                }}
+              >
+                {changedSummary} finished updating availability. This digest waited until the board was
+                quiet before sending.
+              </p>
+            </div>
+
+            <div style={{ padding: "28px 32px 32px" }}>
+              <div
+                style={{
+                  borderRadius: "14px",
+                  border: "1px solid rgba(22, 56, 72, 0.08)",
+                  backgroundColor: "#f7fbfb",
+                  padding: "18px 20px",
+                  marginBottom: "22px",
+                }}
+              >
+                <p
+                  style={{
+                    margin: "0 0 8px",
+                    fontSize: "12px",
+                    fontWeight: 700,
+                    letterSpacing: "0.08em",
+                    textTransform: "uppercase",
+                    color: muted,
+                  }}
+                >
+                  Event timezone
+                </p>
+                <p style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>{eventTimezone}</p>
+              </div>
+
+              <div style={{ marginBottom: "22px" }}>
+                <p
+                  style={{
+                    margin: "0 0 12px",
+                    fontSize: "12px",
+                    fontWeight: 700,
+                    letterSpacing: "0.08em",
+                    textTransform: "uppercase",
+                    color: muted,
+                  }}
+                >
+                  {finalizedSlotLabel ? "Fixed date" : "Best windows right now"}
+                </p>
+
+                {finalizedSlotLabel ? (
+                  <div
+                    style={{
+                      borderRadius: "14px",
+                      backgroundColor: "#163848",
+                      color: "#ffffff",
+                      padding: "18px 20px",
+                    }}
+                  >
+                    <p style={{ margin: 0, fontSize: "18px", fontWeight: 700 }}>{finalizedSlotLabel}</p>
+                    <p
+                      style={{
+                        margin: "8px 0 0",
+                        fontSize: "14px",
+                        lineHeight: 1.6,
+                        color: "rgba(255, 255, 255, 0.82)",
+                      }}
+                    >
+                      The board is closed and this is the published meeting slot.
+                    </p>
+                  </div>
+                ) : (
+                  currentBestWindows.map((label, index) => (
+                    <div
+                      key={label}
+                      style={{
+                        padding: "16px 18px",
+                        borderRadius: "14px",
+                        border: "1px solid rgba(22, 56, 72, 0.08)",
+                        backgroundColor: index === 0 ? "rgba(14, 134, 144, 0.08)" : "#ffffff",
+                        marginBottom: index === currentBestWindows.length - 1 ? 0 : 10,
+                      }}
+                    >
+                      <p
+                        style={{
+                          margin: "0 0 4px",
+                          fontSize: "12px",
+                          fontWeight: 700,
+                          letterSpacing: "0.08em",
+                          textTransform: "uppercase",
+                          color: muted,
+                        }}
+                      >
+                        Option {index + 1}
+                      </p>
+                      <p style={{ margin: 0, fontSize: "17px", fontWeight: 650 }}>{label}</p>
+                    </div>
+                  ))
+                )}
+              </div>
+
+              <div style={{ marginBottom: "22px" }}>
+                <a
+                  href={manageUrl}
+                  style={{
+                    display: "block",
+                    padding: "14px 20px",
+                    borderRadius: "12px",
+                    backgroundColor: accent,
+                    color: "#ffffff",
+                    fontSize: "16px",
+                    fontWeight: 700,
+                    textAlign: "center",
+                    textDecoration: "none",
+                  }}
+                >
+                  Open private organizer link
+                </a>
+                <p
+                  style={{
+                    margin: "10px 0 0",
+                    fontSize: "13px",
+                    lineHeight: 1.6,
+                    color: muted,
+                  }}
+                >
+                  Sensitive link. Keep it private.
+                </p>
+              </div>
+
+              <div
+                style={{
+                  borderTop: "1px solid rgba(22, 56, 72, 0.08)",
+                  paddingTop: "20px",
+                }}
+              >
+                <a
+                  href={publicUrl}
+                  style={{
+                    color: accent,
+                    fontSize: "14px",
+                    fontWeight: 700,
+                    textDecoration: "none",
+                  }}
+                >
+                  View the public board
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}
+
+export async function buildAvailabilityDigestEmail(event: NotificationEvent) {
+  const snapshot = buildNotificationSnapshot(event);
+  const locale = getNotificationLocale();
+  const notification = event.availabilityNotification;
+  const pendingParticipantIds = Array.from(new Set(notification?.pendingParticipantIds ?? []));
+  const changedParticipants = pendingParticipantIds
+    .map((participantId) =>
+      event.participants.find((participant) => participant.id === participantId)?.displayName,
+    )
+    .filter((participantName): participantName is string => Boolean(participantName));
+  const rawEmailManageToken = createOpaqueToken();
+  const manageUrl = buildManageUrl(buildManageKey(event.id, rawEmailManageToken));
+  const publicUrl = buildPublicEventUrl(event.slug);
+  const bestWindows = snapshot.suggestions.map((suggestion) => suggestion.label);
+  const finalizedSlotLabel = snapshot.finalizedSlot?.label ?? null;
+  const { renderToStaticMarkup } = await import("react-dom/server");
+  const html = `<!DOCTYPE html>${renderToStaticMarkup(
+    <AvailabilityDigestEmail
+      changedParticipants={changedParticipants}
+      currentBestWindows={bestWindows}
+      eventTitle={event.title}
+      eventTimezone={event.timezone}
+      finalizedSlotLabel={finalizedSlotLabel}
+      manageUrl={manageUrl}
+      publicUrl={publicUrl}
+    />,
+  )}`;
+
+  const digestAt = notification?.pendingFlushAfterAt
+    ? formatNotificationDate(notification.pendingFlushAfterAt, event.timezone, locale)
+    : null;
+  const overviewLines = finalizedSlotLabel
+    ? [`Fixed date: ${finalizedSlotLabel}`]
+    : bestWindows.slice(0, 3).map((label, index) => `Option ${index + 1}: ${label}`);
+  const text = [
+    `${appConfig.appName}`,
+    "",
+    `${formatChangedParticipants(changedParticipants)} updated availability on ${event.title}.`,
+    digestAt ? `Digest sent after quiet period ending at ${digestAt}.` : null,
+    `Event timezone: ${event.timezone}`,
+    "",
+    ...overviewLines,
+    "",
+    `Private organizer link (keep private): ${manageUrl}`,
+    `Public board: ${publicUrl}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return {
+    rawEmailManageToken,
+    subject: buildDigestSubject(event.title, changedParticipants),
+    html,
+    text,
+  };
+}
+
+export function buildManageEventNotificationState(
+  notification: NotificationRow | null | undefined,
+): ManageEventNotificationState {
+  return {
+    isConfigured: isNotificationDeliveryConfigured(),
+    recipientEmail: notification?.recipientEmail ?? null,
+    quietPeriodMinutes: DIGEST_QUIET_PERIOD_MINUTES,
+    lastSentAt: notification?.lastSentAt?.toISOString() ?? null,
+    pendingDigest:
+      notification?.recipientEmail && notification.pendingFlushAfterAt
+        ? {
+            participantCount: new Set(notification.pendingParticipantIds).size,
+            flushAfterAt: notification.pendingFlushAfterAt.toISOString(),
+          }
+        : null,
+  };
+}
+
+async function reschedulePendingDigest(eventId: string) {
+  const notification = await prisma.eventAvailabilityNotification.findUnique({
+    where: {
+      eventId,
+    },
+    select: {
+      pendingFlushAfterAt: true,
+    },
+  });
+
+  if (notification?.pendingFlushAfterAt) {
+    scheduleDigestTimer(eventId, notification.pendingFlushAfterAt);
+  } else {
+    clearDigestTimer(eventId);
+  }
+}
+
+async function flushAvailabilityDigest(eventId: string) {
+  if (!isNotificationDeliveryConfigured()) {
+    return;
+  }
+
+  const event = await getEventForDigest(eventId);
+  if (!event?.availabilityNotification?.recipientEmail || !event.availabilityNotification.pendingFlushAfterAt) {
+    clearDigestTimer(eventId);
+    return;
+  }
+
+  if (event.availabilityNotification.pendingFlushAfterAt.getTime() > Date.now()) {
+    scheduleDigestTimer(eventId, event.availabilityNotification.pendingFlushAfterAt);
+    return;
+  }
+
+  const { rawEmailManageToken, subject, html, text } = await buildAvailabilityDigestEmail(event);
+  const previousEmailManageTokenHash = event.availabilityNotification.emailManageTokenHash;
+  const emailManageTokenHash = hashSecret(rawEmailManageToken);
+
+  await prisma.eventAvailabilityNotification.update({
+    where: {
+      eventId,
+    },
+    data: {
+      emailManageTokenHash,
+    },
+  });
+
+  try {
+    const resend = getResendClient();
+    const sendResult = await resend.emails.send({
+      from: `${notificationConfig.resendFromName ?? appConfig.appName} <${notificationConfig.resendFromEmail!}>`,
+      to: [event.availabilityNotification.recipientEmail],
+      subject,
+      html,
+      text,
+    });
+
+    if ("error" in sendResult && sendResult.error) {
+      throw new Error(
+        typeof sendResult.error === "object" && sendResult.error && "message" in sendResult.error
+          ? String(sendResult.error.message)
+          : "Unable to send digest email.",
+      );
+    }
+
+    await prisma.eventAvailabilityNotification.update({
+      where: {
+        eventId,
+      },
+      data: {
+        lastSentAt: new Date(),
+        pendingSinceAt: null,
+        pendingFlushAfterAt: null,
+        pendingParticipantIds: {
+          set: [],
+        },
+        pendingChangeCount: 0,
+      },
+    });
+  } catch (error) {
+    const nextFlushAfterAt = new Date(Date.now() + DIGEST_QUIET_PERIOD_MS);
+
+    await prisma.eventAvailabilityNotification.update({
+      where: {
+        eventId,
+      },
+      data: {
+        emailManageTokenHash: previousEmailManageTokenHash,
+        pendingFlushAfterAt: nextFlushAfterAt,
+      },
+    });
+
+    scheduleDigestTimer(eventId, nextFlushAfterAt);
+    console.error("[availability-notifications] Failed to send digest", error);
+    return;
+  }
+
+  clearDigestTimer(eventId);
+}
+
+export async function ensureAvailabilityDigestSchedulerStarted() {
+  if (!isNotificationDeliveryConfigured()) {
+    return;
+  }
+
+  if (globalForAvailabilityNotifications.availabilityDigestRecovered) {
+    return;
+  }
+
+  if (!globalForAvailabilityNotifications.availabilityDigestRecoveryPromise) {
+    globalForAvailabilityNotifications.availabilityDigestRecoveryPromise = (async () => {
+      const pendingNotifications = await prisma.eventAvailabilityNotification.findMany({
+        where: {
+          recipientEmail: {
+            not: null,
+          },
+          pendingFlushAfterAt: {
+            not: null,
+          },
+        },
+        select: {
+          eventId: true,
+          pendingFlushAfterAt: true,
+        },
+      });
+
+      for (const notification of pendingNotifications) {
+        if (!notification.pendingFlushAfterAt) {
+          continue;
+        }
+
+        scheduleDigestTimer(notification.eventId, notification.pendingFlushAfterAt);
+      }
+
+      globalForAvailabilityNotifications.availabilityDigestRecovered = true;
+    })().finally(() => {
+      globalForAvailabilityNotifications.availabilityDigestRecoveryPromise = undefined;
+    });
+  }
+
+  await globalForAvailabilityNotifications.availabilityDigestRecoveryPromise;
+}
+
+export async function queueAvailabilityDigest(options: {
+  eventId: string;
+  participantId: string;
+  recipientEmail: string;
+}) {
+  const recipientEmail = normalizeNotificationEmail(options.recipientEmail);
+  if (!recipientEmail || !isNotificationDeliveryConfigured()) {
+    return;
+  }
+
+  const now = new Date();
+  const flushAfterAt = new Date(now.getTime() + DIGEST_QUIET_PERIOD_MS);
+  const existing = await prisma.eventAvailabilityNotification.findUnique({
+    where: {
+      eventId: options.eventId,
+    },
+    select: {
+      pendingSinceAt: true,
+      pendingParticipantIds: true,
+      pendingChangeCount: true,
+    },
+  });
+
+  const data = {
+    recipientEmail,
+    pendingSinceAt: existing?.pendingSinceAt ?? now,
+    pendingFlushAfterAt: flushAfterAt,
+    pendingParticipantIds: {
+      set: Array.from(new Set([...(existing?.pendingParticipantIds ?? []), options.participantId])),
+    },
+    pendingChangeCount: (existing?.pendingChangeCount ?? 0) + 1,
+  };
+
+  if (existing) {
+    await prisma.eventAvailabilityNotification.update({
+      where: {
+        eventId: options.eventId,
+      },
+      data,
+    });
+  } else {
+    try {
+      await prisma.eventAvailabilityNotification.create({
+        data: {
+          eventId: options.eventId,
+          recipientEmail,
+          pendingSinceAt: now,
+          pendingFlushAfterAt: flushAfterAt,
+          pendingParticipantIds: [options.participantId],
+          pendingChangeCount: 1,
+        },
+      });
+    } catch (error) {
+      if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== "P2002") {
+        throw error;
+      }
+
+      const current = await prisma.eventAvailabilityNotification.findUnique({
+        where: {
+          eventId: options.eventId,
+        },
+        select: {
+          pendingSinceAt: true,
+          pendingParticipantIds: true,
+          pendingChangeCount: true,
+        },
+      });
+
+      await prisma.eventAvailabilityNotification.update({
+        where: {
+          eventId: options.eventId,
+        },
+        data: {
+          recipientEmail,
+          pendingSinceAt: current?.pendingSinceAt ?? now,
+          pendingFlushAfterAt: flushAfterAt,
+          pendingParticipantIds: {
+            set: Array.from(
+              new Set([...(current?.pendingParticipantIds ?? []), options.participantId]),
+            ),
+          },
+          pendingChangeCount: (current?.pendingChangeCount ?? 0) + 1,
+        },
+      });
+    }
+  }
+
+  scheduleDigestTimer(options.eventId, flushAfterAt);
+}
+
+export async function updateNotificationRecipient(eventId: string, notificationEmail?: string) {
+  const recipientEmail = normalizeNotificationEmail(notificationEmail);
+
+  if (recipientEmail && !isNotificationDeliveryConfigured()) {
+    throw serviceUnavailable("notification_delivery_unavailable");
+  }
+
+  if (!recipientEmail) {
+    clearDigestTimer(eventId);
+
+    const existing = await prisma.eventAvailabilityNotification.findUnique({
+      where: {
+        eventId,
+      },
+      select: {
+        eventId: true,
+      },
+    });
+
+    if (existing) {
+      await prisma.eventAvailabilityNotification.update({
+        where: {
+          eventId,
+        },
+        data: {
+          recipientEmail: null,
+          emailManageTokenHash: null,
+          pendingSinceAt: null,
+          pendingFlushAfterAt: null,
+          pendingParticipantIds: {
+            set: [],
+          },
+          pendingChangeCount: 0,
+        },
+      });
+    }
+
+    const notification = await prisma.eventAvailabilityNotification.findUnique({
+      where: {
+        eventId,
+      },
+      select: {
+        recipientEmail: true,
+        pendingFlushAfterAt: true,
+        pendingParticipantIds: true,
+        lastSentAt: true,
+      },
+    });
+
+    return buildManageEventNotificationState(notification);
+  }
+
+  const existing = await prisma.eventAvailabilityNotification.findUnique({
+    where: {
+      eventId,
+    },
+    select: {
+      eventId: true,
+    },
+  });
+
+  if (existing) {
+    await prisma.eventAvailabilityNotification.update({
+      where: {
+        eventId,
+      },
+      data: {
+        recipientEmail,
+      },
+    });
+  } else {
+    await prisma.eventAvailabilityNotification.create({
+      data: {
+        eventId,
+        recipientEmail,
+      },
+    });
+  }
+
+  await reschedulePendingDigest(eventId);
+
+  const notification = await prisma.eventAvailabilityNotification.findUnique({
+    where: {
+      eventId,
+    },
+    select: {
+      recipientEmail: true,
+      pendingFlushAfterAt: true,
+      pendingParticipantIds: true,
+      lastSentAt: true,
+    },
+  });
+
+  return buildManageEventNotificationState(notification);
+}
+
+export function resetAvailabilityNotificationsForTests() {
+  for (const timer of getDigestTimers().values()) {
+    clearTimeout(timer);
+  }
+
+  getDigestTimers().clear();
+  globalForAvailabilityNotifications.availabilityDigestRecoveryPromise = undefined;
+  globalForAvailabilityNotifications.availabilityDigestRecovered = false;
+  globalForAvailabilityNotifications.availabilityDigestResend = undefined;
+}
+
+export function getAvailabilityDigestQuietPeriodMinutes() {
+  return DIGEST_QUIET_PERIOD_MINUTES;
+}

--- a/src/lib/availability-notifications.tsx
+++ b/src/lib/availability-notifications.tsx
@@ -12,6 +12,7 @@ import type { ManageEventNotificationState } from "@/lib/types";
 
 const DIGEST_QUIET_PERIOD_MINUTES = notificationConfig.quietPeriodMinutes;
 const DIGEST_QUIET_PERIOD_MS = DIGEST_QUIET_PERIOD_MINUTES * 60 * 1000;
+const MAX_DIGEST_QUEUE_ATTEMPTS = 3;
 
 type NotificationRow = {
   recipientEmail: string | null;
@@ -665,82 +666,82 @@ export async function queueAvailabilityDigest(options: {
 
   const now = new Date();
   const flushAfterAt = new Date(now.getTime() + DIGEST_QUIET_PERIOD_MS);
-  const existing = await prisma.eventAvailabilityNotification.findUnique({
-    where: {
-      eventId: options.eventId,
-    },
-    select: {
-      pendingSinceAt: true,
-      pendingParticipantIds: true,
-      pendingChangeCount: true,
-    },
-  });
-
-  const data = {
-    recipientEmail,
-    pendingSinceAt: existing?.pendingSinceAt ?? now,
-    pendingFlushAfterAt: flushAfterAt,
-    pendingParticipantIds: {
-      set: Array.from(new Set([...(existing?.pendingParticipantIds ?? []), options.participantId])),
-    },
-    pendingChangeCount: (existing?.pendingChangeCount ?? 0) + 1,
-  };
-
-  if (existing) {
-    await prisma.eventAvailabilityNotification.update({
-      where: {
-        eventId: options.eventId,
-      },
-      data,
-    });
-  } else {
+  for (let attempt = 1; attempt <= MAX_DIGEST_QUEUE_ATTEMPTS; attempt += 1) {
     try {
-      await prisma.eventAvailabilityNotification.create({
-        data: {
-          eventId: options.eventId,
-          recipientEmail,
-          pendingSinceAt: now,
-          pendingFlushAfterAt: flushAfterAt,
-          pendingParticipantIds: [options.participantId],
-          pendingChangeCount: 1,
+      const shouldScheduleDigest = await prisma.$transaction(
+        async (tx) => {
+          const existing = await tx.eventAvailabilityNotification.findUnique({
+            where: {
+              eventId: options.eventId,
+            },
+            select: {
+              recipientEmail: true,
+              pendingSinceAt: true,
+              pendingParticipantIds: true,
+            },
+          });
+
+          if (existing) {
+            if (!existing.recipientEmail) {
+              return false;
+            }
+
+            await tx.eventAvailabilityNotification.update({
+              where: {
+                eventId: options.eventId,
+              },
+              data: {
+                pendingSinceAt: existing.pendingSinceAt ?? now,
+                pendingFlushAfterAt: flushAfterAt,
+                pendingParticipantIds: {
+                  set: Array.from(
+                    new Set([...existing.pendingParticipantIds, options.participantId]),
+                  ),
+                },
+                pendingChangeCount: {
+                  increment: 1,
+                },
+              },
+            });
+
+            return true;
+          }
+
+          await tx.eventAvailabilityNotification.create({
+            data: {
+              eventId: options.eventId,
+              recipientEmail,
+              pendingSinceAt: now,
+              pendingFlushAfterAt: flushAfterAt,
+              pendingParticipantIds: [options.participantId],
+              pendingChangeCount: 1,
+            },
+          });
+
+          return true;
         },
-      });
-    } catch (error) {
-      if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== "P2002") {
-        throw error;
+        {
+          isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+        },
+      );
+
+      if (shouldScheduleDigest) {
+        scheduleDigestTimer(options.eventId, flushAfterAt);
+      } else {
+        clearDigestTimer(options.eventId);
       }
 
-      const current = await prisma.eventAvailabilityNotification.findUnique({
-        where: {
-          eventId: options.eventId,
-        },
-        select: {
-          pendingSinceAt: true,
-          pendingParticipantIds: true,
-          pendingChangeCount: true,
-        },
-      });
+      return;
+    } catch (error) {
+      const isRetryableConcurrencyError =
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        (error.code === "P2002" || error.code === "P2034");
 
-      await prisma.eventAvailabilityNotification.update({
-        where: {
-          eventId: options.eventId,
-        },
-        data: {
-          recipientEmail,
-          pendingSinceAt: current?.pendingSinceAt ?? now,
-          pendingFlushAfterAt: flushAfterAt,
-          pendingParticipantIds: {
-            set: Array.from(
-              new Set([...(current?.pendingParticipantIds ?? []), options.participantId]),
-            ),
-          },
-          pendingChangeCount: (current?.pendingChangeCount ?? 0) + 1,
-        },
-      });
+      if (!isRetryableConcurrencyError || attempt === MAX_DIGEST_QUEUE_ATTEMPTS) {
+        throw error;
+      }
     }
   }
-
-  scheduleDigestTimer(options.eventId, flushAfterAt);
 }
 
 export async function updateNotificationRecipient(eventId: string, notificationEmail?: string) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -41,6 +41,17 @@ export const appConfig = {
   sessionMaxAgeSeconds: 60 * 60 * 24 * 30,
 };
 
+export const notificationConfig = {
+  quietPeriodMinutes: 5,
+  resendApiKey: getEnv("RESEND_API_KEY"),
+  resendFromEmail: getEnv("RESEND_FROM_EMAIL"),
+  resendFromName: getEnv("RESEND_FROM_NAME") ?? "tempoll",
+};
+
+export function isNotificationDeliveryConfigured() {
+  return Boolean(notificationConfig.resendApiKey && notificationConfig.resendFromEmail);
+}
+
 export function getDatabaseUrl() {
   const databaseUrl = getEnv("DATABASE_URL");
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -91,3 +91,13 @@ export function tooManyRequests(
     },
   });
 }
+
+export function serviceUnavailable(
+  code = "service_unavailable",
+  options?: {
+    params?: Record<string, string | number>;
+    headers?: Record<string, string>;
+  },
+) {
+  return new AppError(503, code, options);
+}

--- a/src/lib/event-service.save-availability.test.ts
+++ b/src/lib/event-service.save-availability.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildSlotStart } from "@/lib/availability";
+import { hashSecret } from "@/lib/tokens";
+
+const prisma = {
+  participant: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+  availabilitySlot: {
+    deleteMany: vi.fn(),
+    createMany: vi.fn(),
+  },
+  event: {
+    findUnique: vi.fn(),
+  },
+  $transaction: vi.fn(),
+};
+
+const publishEventUpdate = vi.fn();
+const queueAvailabilityDigest = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma,
+}));
+
+vi.mock("@/lib/realtime", () => ({
+  publishEventUpdate,
+}));
+
+vi.mock("@/lib/availability-notifications", () => ({
+  ensureAvailabilityDigestSchedulerStarted: vi.fn(),
+  queueAvailabilityDigest,
+  buildManageEventNotificationState: vi.fn(),
+  updateNotificationRecipient: vi.fn(),
+}));
+
+function createParticipantForMutation(selectedSlotStarts: string[], recipientEmail = "owner@example.com") {
+  return {
+    id: "participant_1",
+    eventId: "event_1",
+    displayName: "Felix",
+    color: "#ef7f3b",
+    editTokenHash: hashSecret("secret-token"),
+    availabilitySlots: selectedSlotStarts.map((slotStartAt) => ({
+      slotStartAt: new Date(slotStartAt),
+    })),
+    event: {
+      id: "event_1",
+      slug: "team-sync",
+      title: "Team Sync",
+      timezone: "Europe/Vienna",
+      slotMinutes: 30,
+      meetingDurationMinutes: 60,
+      dayStartMinutes: 9 * 60,
+      dayEndMinutes: 11 * 60,
+      status: "OPEN" as const,
+      finalSlotStartAt: null,
+      manageTokenHash: hashSecret("organizer-secret"),
+      createdAt: new Date("2026-03-28T10:00:00.000Z"),
+      updatedAt: new Date("2026-03-28T10:00:00.000Z"),
+      dates: [
+        {
+          id: "date_1",
+          eventId: "event_1",
+          dateKey: "2026-04-02",
+          createdAt: new Date("2026-03-28T10:00:00.000Z"),
+        },
+      ],
+      availabilityNotification: recipientEmail
+        ? {
+            eventId: "event_1",
+            recipientEmail,
+          }
+        : null,
+    },
+  };
+}
+
+function createEventSnapshotSource(selectedSlotStarts: string[]) {
+  return {
+    id: "event_1",
+    slug: "team-sync",
+    title: "Team Sync",
+    timezone: "Europe/Vienna",
+    slotMinutes: 30,
+    meetingDurationMinutes: 60,
+    dayStartMinutes: 9 * 60,
+    dayEndMinutes: 11 * 60,
+    status: "OPEN" as const,
+    finalSlotStartAt: null,
+    manageTokenHash: hashSecret("organizer-secret"),
+    createdAt: new Date("2026-03-28T10:00:00.000Z"),
+    updatedAt: new Date("2026-03-28T10:00:00.000Z"),
+    dates: [
+      {
+        id: "date_1",
+        eventId: "event_1",
+        dateKey: "2026-04-02",
+        createdAt: new Date("2026-03-28T10:00:00.000Z"),
+      },
+    ],
+    availabilityNotification: null,
+    participants: [
+      {
+        id: "participant_1",
+        displayName: "Felix",
+        color: "#ef7f3b",
+        createdAt: new Date("2026-03-28T10:00:00.000Z"),
+        availabilitySlots: selectedSlotStarts.map((slotStartAt) => ({
+          slotStartAt: new Date(slotStartAt),
+        })),
+      },
+    ],
+  };
+}
+
+describe("saveAvailability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.$transaction.mockImplementation(async (operations: Array<Promise<unknown>>) =>
+      Promise.all(operations),
+    );
+    prisma.participant.update.mockResolvedValue(undefined);
+    prisma.availabilitySlot.deleteMany.mockResolvedValue(undefined);
+    prisma.availabilitySlot.createMany.mockResolvedValue(undefined);
+  });
+
+  it("does not publish or queue a digest when the selection did not change", async () => {
+    const selectedSlotStart = buildSlotStart("2026-04-02", 9 * 60, "Europe/Vienna");
+    prisma.participant.findUnique.mockResolvedValue(createParticipantForMutation([selectedSlotStart]));
+    prisma.event.findUnique.mockResolvedValue(createEventSnapshotSource([selectedSlotStart]));
+
+    const { saveAvailability } = await import("./event-service");
+
+    await saveAvailability(
+      "team-sync",
+      "en",
+      {
+        selectedSlotStarts: [selectedSlotStart],
+      },
+      "participant_1.secret-token",
+    );
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(publishEventUpdate).not.toHaveBeenCalled();
+    expect(queueAvailabilityDigest).not.toHaveBeenCalled();
+    expect(prisma.participant.update).toHaveBeenCalledWith({
+      where: {
+        id: "participant_1",
+      },
+      data: {
+        lastSeenAt: expect.any(Date),
+      },
+    });
+  });
+
+  it("queues a digest after a real availability change", async () => {
+    const existingSlotStart = buildSlotStart("2026-04-02", 9 * 60, "Europe/Vienna");
+    const nextSlotStart = buildSlotStart("2026-04-02", 9 * 60 + 30, "Europe/Vienna");
+    prisma.participant.findUnique.mockResolvedValue(createParticipantForMutation([existingSlotStart]));
+    prisma.event.findUnique.mockResolvedValue(createEventSnapshotSource([nextSlotStart]));
+
+    const { saveAvailability } = await import("./event-service");
+
+    await saveAvailability(
+      "team-sync",
+      "en",
+      {
+        selectedSlotStarts: [nextSlotStart],
+      },
+      "participant_1.secret-token",
+    );
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(publishEventUpdate).toHaveBeenCalledWith({
+      eventId: "event_1",
+      kind: "availability-saved",
+      participantId: "participant_1",
+    });
+    expect(queueAvailabilityDigest).toHaveBeenCalledWith({
+      eventId: "event_1",
+      participantId: "participant_1",
+      recipientEmail: "owner@example.com",
+    });
+  });
+});

--- a/src/lib/event-service.test.ts
+++ b/src/lib/event-service.test.ts
@@ -16,6 +16,7 @@ const prisma = {
 };
 
 const publishEventUpdate = vi.fn();
+const updateNotificationRecipient = vi.fn();
 
 vi.mock("@/lib/prisma", () => ({
   prisma,
@@ -23,6 +24,19 @@ vi.mock("@/lib/prisma", () => ({
 
 vi.mock("@/lib/realtime", () => ({
   publishEventUpdate,
+}));
+
+vi.mock("@/lib/availability-notifications", () => ({
+  ensureAvailabilityDigestSchedulerStarted: vi.fn(),
+  queueAvailabilityDigest: vi.fn(),
+  buildManageEventNotificationState: vi.fn(() => ({
+    isConfigured: true,
+    recipientEmail: null,
+    quietPeriodMinutes: 5,
+    lastSentAt: null,
+    pendingDigest: null,
+  })),
+  updateNotificationRecipient,
 }));
 
 function createManagedEvent() {
@@ -48,6 +62,7 @@ function createManagedEvent() {
         createdAt: new Date("2026-03-28T10:00:00.000Z"),
       },
     ],
+    availabilityNotification: null,
     participants: [],
   };
 }
@@ -59,6 +74,13 @@ describe("updateManagedEvent", () => {
     prisma.event.findUnique.mockResolvedValue(createManagedEvent());
     prisma.event.update.mockResolvedValue(undefined);
     publishEventUpdate.mockResolvedValue(undefined);
+    updateNotificationRecipient.mockResolvedValue({
+      isConfigured: true,
+      recipientEmail: "owner@example.com",
+      quietPeriodMinutes: 5,
+      lastSentAt: null,
+      pendingDigest: null,
+    });
   });
 
   it("stores a valid fixed date when closing an event", async () => {
@@ -131,5 +153,36 @@ describe("updateManagedEvent", () => {
         title: "Renamed sync",
       },
     });
+  });
+
+  it("updates organizer notification email settings", async () => {
+    const { updateManagedEvent } = await import("./event-service");
+
+    const result = await updateManagedEvent("event_1.secret", {
+      action: "updateNotificationEmail",
+      notificationEmail: "owner@example.com",
+    });
+
+    expect(updateNotificationRecipient).toHaveBeenCalledWith("event_1", "owner@example.com");
+    expect(result).toEqual({
+      notification: {
+        isConfigured: true,
+        recipientEmail: "owner@example.com",
+        quietPeriodMinutes: 5,
+        lastSentAt: null,
+        pendingDigest: null,
+      },
+    });
+  });
+
+  it("clears organizer notification email settings", async () => {
+    const { updateManagedEvent } = await import("./event-service");
+
+    await updateManagedEvent("event_1.secret", {
+      action: "updateNotificationEmail",
+      notificationEmail: "",
+    });
+
+    expect(updateNotificationRecipient).toHaveBeenCalledWith("event_1", "");
   });
 });

--- a/src/lib/event-service.ts
+++ b/src/lib/event-service.ts
@@ -1,6 +1,12 @@
 import { Prisma } from "@prisma/client";
 
-import { appConfig } from "@/lib/config";
+import {
+  buildManageEventNotificationState,
+  ensureAvailabilityDigestSchedulerStarted,
+  queueAvailabilityDigest,
+  updateNotificationRecipient,
+} from "@/lib/availability-notifications";
+import { appConfig, isNotificationDeliveryConfigured } from "@/lib/config";
 import type { AppLocale } from "@/lib/i18n/locale";
 import { prisma } from "@/lib/prisma";
 import {
@@ -23,7 +29,7 @@ import {
   parseParticipantCookieValue,
   pickParticipantColor,
 } from "@/lib/tokens";
-import { conflict, notFound, unauthorized } from "@/lib/errors";
+import { conflict, notFound, serviceUnavailable, unauthorized } from "@/lib/errors";
 import type {
   AvailabilityBatchMutation,
   CreateEventResult,
@@ -53,6 +59,7 @@ type EventWithRelations = Prisma.EventGetPayload<{
         };
       };
     };
+    availabilityNotification: true;
   };
 }>;
 
@@ -77,6 +84,7 @@ async function getEventWithRelationsBySlug(slug: string) {
           },
         },
       },
+      availabilityNotification: true,
     },
   });
 }
@@ -102,6 +110,7 @@ async function getEventWithRelationsById(id: string) {
           },
         },
       },
+      availabilityNotification: true,
     },
   });
 }
@@ -182,6 +191,10 @@ async function getParticipantByEditLink(slug: string, participantId: string, tok
 }
 
 export async function createEvent(input: EventCreateInput): Promise<CreateEventResult> {
+  if (input.notificationEmail && !isNotificationDeliveryConfigured()) {
+    throw serviceUnavailable("notification_delivery_unavailable");
+  }
+
   let slug = makeSlug(input.title);
   while (await prisma.event.findUnique({ where: { slug }, select: { id: true } })) {
     slug = makeSlug(input.title);
@@ -205,6 +218,13 @@ export async function createEvent(input: EventCreateInput): Promise<CreateEventR
           data: input.dates.map((dateKey) => ({ dateKey })),
         },
       },
+      availabilityNotification: input.notificationEmail
+        ? {
+            create: {
+              recipientEmail: input.notificationEmail.trim().toLowerCase(),
+            },
+          }
+        : undefined,
     },
     select: {
       id: true,
@@ -223,6 +243,8 @@ export async function getPublicEventSnapshot(
   locale: AppLocale,
   cookieValue?: string,
 ) {
+  await ensureAvailabilityDigestSchedulerStarted();
+
   const [event, participant] = await Promise.all([
     getEventWithRelationsBySlug(slug),
     getParticipantForSession(slug, cookieValue),
@@ -333,6 +355,16 @@ async function verifyParticipantMutation(slug: string, cookieValue?: string) {
               dateKey: "asc",
             },
           },
+          availabilityNotification: {
+            select: {
+              recipientEmail: true,
+            },
+          },
+        },
+      },
+      availabilitySlots: {
+        select: {
+          slotStartAt: true,
         },
       },
     },
@@ -355,6 +387,8 @@ export async function saveAvailability(
   mutation: AvailabilityBatchMutation,
   cookieValue?: string,
 ) {
+  await ensureAvailabilityDigestSchedulerStarted();
+
   const participant = await verifyParticipantMutation(slug, cookieValue);
   const allowedSlots = getAllowedSlotStarts({
     dates: participant.event.dates.map((date) => date.dateKey),
@@ -368,6 +402,33 @@ export async function saveAvailability(
   const invalidSlot = uniqueSlotStarts.find((slotStart) => !allowedSlots.has(slotStart));
   if (invalidSlot) {
     throw conflict("invalid_slots");
+  }
+
+  const currentSelectionSignature = participant.availabilitySlots
+    .map((slot) => slot.slotStartAt.toISOString())
+    .sort()
+    .join("|");
+  const nextSelectionSignature = [...uniqueSlotStarts].sort().join("|");
+  const didAvailabilityChange = currentSelectionSignature !== nextSelectionSignature;
+
+  if (!didAvailabilityChange) {
+    await prisma.participant.update({
+      where: {
+        id: participant.id,
+      },
+      data: {
+        lastSeenAt: new Date(),
+      },
+    });
+
+    const event = await getEventWithRelationsById(participant.eventId);
+    if (!event) {
+      throw notFound("event_not_found");
+    }
+
+    return {
+      snapshot: toSnapshot(event, locale, participant.id),
+    };
   }
 
   await prisma.$transaction([
@@ -408,6 +469,14 @@ export async function saveAvailability(
     participantId: participant.id,
   });
 
+  if (participant.event.availabilityNotification?.recipientEmail) {
+    await queueAvailabilityDigest({
+      eventId: participant.eventId,
+      participantId: participant.id,
+      recipientEmail: participant.event.availabilityNotification.recipientEmail,
+    });
+  }
+
   return {
     snapshot: toSnapshot(event, locale, participant.id),
   };
@@ -425,7 +494,9 @@ async function verifyManageKey(manageKey: string) {
   }
 
   if (event.manageTokenHash !== hashSecret(parsed.token)) {
-    throw notFound("manage_key_invalid");
+    if (event.availabilityNotification?.emailManageTokenHash !== hashSecret(parsed.token)) {
+      throw notFound("manage_key_invalid");
+    }
   }
 
   return event;
@@ -436,6 +507,8 @@ export async function getManageEventView(
   locale: AppLocale,
 ): Promise<ManageEventView | null> {
   try {
+    await ensureAvailabilityDigestSchedulerStarted();
+
     const event = await verifyManageKey(manageKey);
     const snapshot = toSnapshot(event, locale);
 
@@ -444,6 +517,7 @@ export async function getManageEventView(
       shareUrl: buildPublicEventUrl(event.slug),
       manageUrl: buildManageUrl(manageKey),
       snapshot,
+      notification: buildManageEventNotificationState(event.availabilityNotification),
     };
   } catch {
     return null;
@@ -472,6 +546,10 @@ export async function updateManagedEvent(
         action: "renameParticipant";
         participantId: string;
         displayName: string;
+      }
+    | {
+        action: "updateNotificationEmail";
+        notificationEmail?: string;
       },
 ) {
   const event = await verifyManageKey(manageKey);
@@ -561,11 +639,26 @@ export async function updateManagedEvent(
     }
   }
 
+  if (input.action === "updateNotificationEmail") {
+    const notification = await updateNotificationRecipient(event.id, input.notificationEmail);
+
+    await publishEventUpdate({
+      eventId: event.id,
+      kind: "event-updated",
+    });
+
+    return {
+      notification,
+    };
+  }
+
   await publishEventUpdate({
     eventId: event.id,
     kind: input.action === "renameParticipant" ? "participant-renamed" : "event-updated",
     participantId: input.action === "renameParticipant" ? input.participantId : undefined,
   });
+
+  return {};
 }
 
 export async function deleteParticipant(manageKey: string, participantId: string) {

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -129,6 +129,12 @@ export const en = {
     slotSizePlaceholder: "Choose slot size",
     meetingDurationLabel: "Meeting duration",
     meetingDurationPlaceholder: "Choose duration",
+    notificationEmailLabel: "Organizer email alerts",
+    notificationEmailPlaceholder: "owner@company.com",
+    notificationEmailDescription:
+      "Optional. Get one email after 5 quiet minutes when participants finish updating availability.",
+    notificationEmailUnavailable:
+      "Email alerts are not available on this host yet.",
     createButton: "Create event",
     genericSettingsError: "Please check your event settings.",
     createFailed: "Unable to create the event.",
@@ -252,6 +258,8 @@ export const en = {
     eventReopened: "Event reopened",
     participantRenamed: "Participant renamed",
     participantRemoved: "Participant removed",
+    notificationEmailSaved: "Email alerts updated",
+    notificationEmailCleared: "Email alerts turned off",
     titleLabel: "Title",
     saveTitle: "Save title",
     eventStatusTitle: "Event status",
@@ -272,6 +280,19 @@ export const en = {
     openPublicEvent: "Open public event",
     copyPublicUrl: "Copy public URL",
     copyOrganizerUrl: "Copy organizer URL",
+    emailAlertsTitle: "Email alerts",
+    emailAlertsDescription:
+      "Get one digest after 5 quiet minutes when participants finish updating availability.",
+    emailAlertsUnavailable:
+      "Email alerts are not available on this host right now.",
+    emailAlertsRecipientLabel: "Send alerts to",
+    emailAlertsSave: "Save email",
+    emailAlertsClear: "Turn off alerts",
+    emailAlertsPending: "A digest is queued for {timestamp}.",
+    emailAlertsLastSent: "Last digest sent {timestamp}.",
+    emailAlertsIdle: "No digest is queued right now.",
+    emailAlertsPrivateLinkNote:
+      "Each email includes a fresh private organizer link. Treat it as sensitive.",
     bestWindowsTitle: "Best windows right now",
     fixedDatePublishedDescription:
       "This is the published fixed date for the closed event.",
@@ -542,6 +563,7 @@ export const en = {
       manageKeyInvalid: "Event not found.",
       finalSlotRequired: "Pick a fixed date before closing this event.",
       finalSlotInvalid: "Pick a valid fixed date that fits the full meeting duration.",
+      notificationDeliveryUnavailable: "Email alerts are not available on this host.",
     },
     rateLimit: {
       eventCreate: "Too many event creation attempts. Please wait a few minutes and try again.",
@@ -727,6 +749,12 @@ export const de: Messages = {
     slotSizePlaceholder: "Slot-Größe wählen",
     meetingDurationLabel: "Meeting-Dauer",
     meetingDurationPlaceholder: "Dauer wählen",
+    notificationEmailLabel: "Organizer-E-Mail-Benachrichtigungen",
+    notificationEmailPlaceholder: "[PRIVATE_EMAIL]",
+    notificationEmailDescription:
+      "Optional. Erhalte eine E-Mail, nachdem Teilnehmende ihre Verfügbarkeit 5 ruhige Minuten lang nicht mehr geändert haben.",
+    notificationEmailUnavailable:
+      "E-Mail-Benachrichtigungen sind auf diesem Host noch nicht verfügbar.",
     createButton: "Event erstellen",
     genericSettingsError: "Bitte prüfe deine Event-Einstellungen.",
     createFailed: "Das Event konnte nicht erstellt werden.",
@@ -858,6 +886,8 @@ export const de: Messages = {
     eventReopened: "Event wieder geöffnet",
     participantRenamed: "Teilnehmende Person umbenannt",
     participantRemoved: "Teilnehmende Person entfernt",
+    notificationEmailSaved: "E-Mail-Benachrichtigungen aktualisiert",
+    notificationEmailCleared: "E-Mail-Benachrichtigungen ausgeschaltet",
     titleLabel: "Titel",
     saveTitle: "Titel speichern",
     eventStatusTitle: "Eventstatus",
@@ -879,6 +909,19 @@ export const de: Messages = {
     openPublicEvent: "Öffentliches Event öffnen",
     copyPublicUrl: "Öffentliche URL kopieren",
     copyOrganizerUrl: "Organizer-URL kopieren",
+    emailAlertsTitle: "E-Mail-Benachrichtigungen",
+    emailAlertsDescription:
+      "Erhalte eine Sammelmail, nachdem Teilnehmende ihre Verfügbarkeit 5 ruhige Minuten lang nicht mehr geändert haben.",
+    emailAlertsUnavailable:
+      "E-Mail-Benachrichtigungen sind auf diesem Host gerade nicht verfügbar.",
+    emailAlertsRecipientLabel: "Benachrichtigungen senden an",
+    emailAlertsSave: "E-Mail speichern",
+    emailAlertsClear: "Benachrichtigungen ausschalten",
+    emailAlertsPending: "Eine Sammelmail ist für {timestamp} eingeplant.",
+    emailAlertsLastSent: "Letzte Sammelmail gesendet {timestamp}.",
+    emailAlertsIdle: "Im Moment ist keine Sammelmail eingeplant.",
+    emailAlertsPrivateLinkNote:
+      "Jede E-Mail enthält einen frischen privaten Organizer-Link. Behandle ihn als sensibel.",
     bestWindowsTitle: "Beste Zeitfenster im Moment",
     fixedDatePublishedDescription:
       "Das ist der veröffentlichte feste Termin für das geschlossene Event.",
@@ -1165,6 +1208,8 @@ export const de: Messages = {
         "Wähle ein fixes Datum aus, bevor du dieses Event schließt.",
       finalSlotInvalid:
         "Wähle ein gültiges fixes Datum, das zur gesamten Meeting-Dauer passt.",
+      notificationDeliveryUnavailable:
+        "E-Mail-Benachrichtigungen sind auf diesem Host nicht verfügbar.",
     },
     rateLimit: {
       eventCreate:

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -92,6 +92,7 @@ function getLocalizedAppErrorMessage(
     manage_key_invalid: messages.errors.app.manageKeyInvalid,
     final_slot_required: messages.errors.app.finalSlotRequired,
     final_slot_invalid: messages.errors.app.finalSlotInvalid,
+    notification_delivery_unavailable: messages.errors.app.notificationDeliveryUnavailable,
     event_create_rate_limited: messages.errors.rateLimit.eventCreate,
     event_join_rate_limited: messages.errors.rateLimit.joinEvent,
     availability_ip_rate_limited: messages.errors.rateLimit.availabilityIp,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,7 @@ export type EventCreateInput = {
   dayEndMinutes: number;
   slotMinutes: number;
   meetingDurationMinutes: number;
+  notificationEmail?: string;
 };
 
 export type ParticipantSession = {
@@ -106,9 +107,23 @@ export type CreateEventResult = {
   manageKey: string;
 };
 
+export type ManageEventNotificationState = {
+  isConfigured: boolean;
+  recipientEmail: string | null;
+  quietPeriodMinutes: number;
+  lastSentAt: string | null;
+  pendingDigest:
+    | {
+        participantCount: number;
+        flushAfterAt: string;
+      }
+    | null;
+};
+
 export type ManageEventView = {
   manageKey: string;
   shareUrl: string;
   manageUrl: string;
   snapshot: PublicEventSnapshot;
+  notification: ManageEventNotificationState;
 };

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -7,6 +7,17 @@ const dateKeyRegex = /^\d{4}-\d{2}-\d{2}$/;
 const slotMinuteSet = new Set<number>(slotMinuteOptions);
 const meetingDurationSet = new Set<number>(meetingDurationOptions);
 
+function createOptionalEmailSchema(messages: Messages) {
+  return z
+    .string()
+    .trim()
+    .max(320, messages.validation.setup.validEmail)
+    .refine((value) => value.length === 0 || z.string().email().safeParse(value).success, {
+      message: messages.validation.setup.validEmail,
+    })
+    .transform((value) => value || undefined);
+}
+
 export function createEventCreateSchema(messages: Messages) {
   return z
     .object({
@@ -38,6 +49,7 @@ export function createEventCreateSchema(messages: Messages) {
         .refine((value) => meetingDurationSet.has(value), {
           message: messages.validation.eventCreate.supportedMeetingDuration,
         }),
+      notificationEmail: createOptionalEmailSchema(messages).optional(),
     })
     .superRefine((data, ctx) => {
       if (data.dayEndMinutes <= data.dayStartMinutes) {
@@ -103,6 +115,10 @@ export function createManageUpdateSchema(messages: Messages) {
         .trim()
         .min(2, messages.validation.participantCreate.nameMin)
         .max(32, messages.validation.participantCreate.nameMax),
+    }),
+    z.object({
+      action: z.literal("updateNotificationEmail"),
+      notificationEmail: createOptionalEmailSchema(messages).optional(),
     }),
   ]);
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -18,6 +18,7 @@ class MockResizeObserver {
 
 afterEach(() => {
   cleanup();
+  localStorageStore.clear();
 });
 
 Object.defineProperty(globalThis, "EventSource", {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -56,3 +56,24 @@ Object.defineProperties(HTMLElement.prototype, {
     value() {},
   },
 });
+
+const localStorageStore = new Map<string, string>();
+
+Object.defineProperty(window, "localStorage", {
+  configurable: true,
+  writable: true,
+  value: {
+    getItem(key: string) {
+      return localStorageStore.has(key) ? localStorageStore.get(key)! : null;
+    },
+    setItem(key: string, value: string) {
+      localStorageStore.set(key, value);
+    },
+    removeItem(key: string) {
+      localStorageStore.delete(key);
+    },
+    clear() {
+      localStorageStore.clear();
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Add optional organizer email alerts backed by Resend and a new notification state model.
- Batch availability changes into a five-minute digest, with retry and rescheduling support in the app process.
- Expose notification email controls in the create flow and manage page, and document the new env vars.

## Testing
- `pnpm verify`
- `pnpm test:run src/lib/availability-notifications.test.tsx`
- `docker build -t tempoll-debug .` not run successfully because the Docker daemon was unavailable