### PR TITLE
Fix Outlook light-mode visibility in availability digest email

### DIFF
--- a/src/lib/availability-notifications.tsx
+++ b/src/lib/availability-notifications.tsx
@@ -251,6 +251,7 @@ function AvailabilityDigestEmail({
             <div
               style={{
                 padding: "28px 32px",
+                backgroundColor: accent,
                 background:
                   "linear-gradient(135deg, rgba(14, 134, 144, 0.96), rgba(16, 112, 126, 0.92))",
                 color: "#ffffff",
@@ -275,6 +276,7 @@ function AvailabilityDigestEmail({
                   margin: "18px 0 8px",
                   fontSize: "30px",
                   lineHeight: 1.15,
+                  color: "#ffffff",
                 }}
               >
                 Availability changed on {eventTitle}
@@ -314,7 +316,9 @@ function AvailabilityDigestEmail({
                 >
                   Event timezone
                 </p>
-                <p style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>{eventTimezone}</p>
+                <p style={{ margin: 0, fontSize: "16px", fontWeight: 600, color: strong }}>
+                  {eventTimezone}
+                </p>
               </div>
 
               <div style={{ marginBottom: "22px" }}>
@@ -340,7 +344,9 @@ function AvailabilityDigestEmail({
                       padding: "18px 20px",
                     }}
                   >
-                    <p style={{ margin: 0, fontSize: "18px", fontWeight: 700 }}>{finalizedSlotLabel}</p>
+                    <p style={{ margin: 0, fontSize: "18px", fontWeight: 700, color: "#ffffff" }}>
+                      {finalizedSlotLabel}
+                    </p>
                     <p
                       style={{
                         margin: "8px 0 0",
@@ -376,7 +382,7 @@ function AvailabilityDigestEmail({
                       >
                         Option {index + 1}
                       </p>
-                      <p style={{ margin: 0, fontSize: "17px", fontWeight: 650 }}>{label}</p>
+                      <p style={{ margin: 0, fontSize: "17px", fontWeight: 650, color: strong }}>{label}</p>
                     </div>
                   ))
                 )}


### PR DESCRIPTION
### Motivation

- Outlook (and some forwarding paths) can ignore CSS gradients or alter colors, causing white hero text to become unreadable on a light background in digest emails. 
- The availability digest is an important notification where readability must be preserved across mail clients and light/dark mode transformations. 
- Making the hero block and critical text colors explicit reduces client-dependent rendering issues.

### Description

- Add a solid `backgroundColor` fallback to the digest hero block so clients that ignore gradients still render a dark header behind white text in `src/lib/availability-notifications.tsx`. 
- Set explicit text colors for the hero headline, timezone value, finalized-slot label, and option labels to avoid inherited/inverted color surprises. 
- Kept the visual gradient while providing the solid-color fallback so clients that support gradients are unaffected.

### Testing

- Ran the availability notifications unit tests with `pnpm test:run src/lib/availability-notifications.test.tsx` and all tests passed. 
- Ran lint with `pnpm lint` and fixed the earlier lint warning, leaving the repository lint-clean. 
- No other automated tests were changed or required for this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e25cd6ea688329a6ddbd787e110d30)