### PR TITLE
Add join gate and stronger day navigation

### DIFF
--- a/src/components/event-heatmap.tsx
+++ b/src/components/event-heatmap.tsx
@@ -244,7 +244,7 @@ function getVisibleRangeLabel(dates: PublicEventSnapshot["dates"]) {
     return dates[0].label;
   }
 
-  return `${dates[0].label} – ${dates[dates.length - 1].label}`;
+  return `${dates[0].label} - ${dates[dates.length - 1].label}`;
 }
 
 function getSlotElementFromPoint(clientX: number, clientY: number) {
@@ -510,6 +510,11 @@ export function EventHeatmap({
   const canShowNextDates =
     usesDateWindowing &&
     clampedVisibleDateStartIndex + visibleDates.length < projectedBoard.dates.length;
+  const dayWindowPrompt = canShowNextDates
+    ? messages.publicEvent.moreDaysAhead
+    : canShowPreviousDates
+      ? messages.publicEvent.earlierDaysAvailable
+      : messages.publicEvent.moreDaysAvailable;
   const visibleRangeLabel = useMemo(() => getVisibleRangeLabel(visibleDates), [visibleDates]);
   const viewerTimezoneOption = useMemo(
     () => findTimezoneOption(timezoneOptions, viewerTimezone),
@@ -1045,22 +1050,26 @@ export function EventHeatmap({
               </div>
 
               {usesDateWindowing ? (
-                <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/20 p-2">
+                <div className="flex items-stretch gap-2 rounded-md border border-primary/30 bg-primary/10 p-2 shadow-sm">
                   <Button
                     type="button"
-                    variant="outline"
-                    size="icon-xs"
+                    variant={canShowPreviousDates ? "secondary" : "outline"}
+                    size="sm"
                     aria-label={messages.publicEvent.showPreviousDays}
                     disabled={!canShowPreviousDates}
+                    className="h-auto self-stretch px-3"
                     onClick={() => moveVisibleDateWindow(-1)}
                   >
                     <ChevronLeftIcon className="size-4" />
                   </Button>
                   <div className="min-w-0 flex-1 text-center">
-                    <p aria-live="polite" className="truncate text-xs font-medium text-foreground">
+                    <p className="text-[11px] font-semibold uppercase text-primary">
+                      {dayWindowPrompt}
+                    </p>
+                    <p aria-live="polite" className="mt-1 truncate text-sm font-semibold text-foreground">
                       {visibleRangeLabel}
                     </p>
-                    <p className="text-[11px] text-muted-foreground">
+                    <p className="text-xs text-muted-foreground">
                       {format(messages.publicEvent.dayWindowSummary, {
                         start: clampedVisibleDateStartIndex + 1,
                         end: clampedVisibleDateStartIndex + visibleDates.length,
@@ -1070,10 +1079,11 @@ export function EventHeatmap({
                   </div>
                   <Button
                     type="button"
-                    variant="outline"
-                    size="icon-xs"
+                    variant={canShowNextDates ? "default" : "outline"}
+                    size="sm"
                     aria-label={messages.publicEvent.showNextDays}
                     disabled={!canShowNextDates}
+                    className="h-auto self-stretch px-3"
                     onClick={() => moveVisibleDateWindow(1)}
                   >
                     <ChevronRightIcon className="size-4" />

--- a/src/components/event-heatmap.tsx
+++ b/src/components/event-heatmap.tsx
@@ -510,11 +510,14 @@ export function EventHeatmap({
   const canShowNextDates =
     usesDateWindowing &&
     clampedVisibleDateStartIndex + visibleDates.length < projectedBoard.dates.length;
-  const dayWindowPrompt = canShowNextDates
-    ? messages.publicEvent.moreDaysAhead
-    : canShowPreviousDates
-      ? messages.publicEvent.earlierDaysAvailable
-      : messages.publicEvent.moreDaysAvailable;
+  const dayWindowPrompt =
+    canShowPreviousDates && canShowNextDates
+      ? messages.publicEvent.moreDaysAvailable
+      : canShowNextDates
+        ? messages.publicEvent.moreDaysAhead
+        : canShowPreviousDates
+          ? messages.publicEvent.earlierDaysAvailable
+          : messages.publicEvent.moreDaysAvailable;
   const visibleRangeLabel = useMemo(() => getVisibleRangeLabel(visibleDates), [visibleDates]);
   const viewerTimezoneOption = useMemo(
     () => findTimezoneOption(timezoneOptions, viewerTimezone),

--- a/src/components/manage-event-client.test.tsx
+++ b/src/components/manage-event-client.test.tsx
@@ -301,7 +301,7 @@ describe("ManageEventClient", () => {
     );
     expect(screen.getByText("03:00")).toBeInTheDocument();
     expect(screen.queryByText("09:00 / 03:00")).not.toBeInTheDocument();
-    expect(screen.getByText("Thu, Apr 2 · 03:00–04:00")).toBeInTheDocument();
+    expect(screen.getByText("Thu, Apr 2 · 03:00-04:00")).toBeInTheDocument();
   });
 
   it("shows local fixed-date labels on the organizer page after a manual timezone override", async () => {
@@ -320,7 +320,7 @@ describe("ManageEventClient", () => {
     await user.click(screen.getByRole("combobox", { name: "Display timezone" }));
     await user.click(screen.getByRole("option", { name: /America\/New_York/ }));
 
-    expect(screen.getByText("Thu, Apr 2 · 03:00–04:00")).toBeInTheDocument();
+    expect(screen.getByText("Thu, Apr 2 · 03:00-04:00")).toBeInTheDocument();
   });
 
   it("closes the event directly from the selected slot without requiring a separate save", async () => {

--- a/src/components/public-event-client.test.tsx
+++ b/src/components/public-event-client.test.tsx
@@ -273,7 +273,7 @@ describe("PublicEventClient", () => {
         slotStart: "2026-03-30T07:00:00.000Z",
         slotEnd: "2026-03-30T08:00:00.000Z",
         dateKey: "2026-03-30",
-        label: "Mon, Mar 30 · 09:00–10:00",
+        label: "Mon, Mar 30 · 09:00-10:00",
         localLabel: null,
         availableCount: 2,
         participantIds: ["p1", "p2"],
@@ -284,7 +284,10 @@ describe("PublicEventClient", () => {
       <PublicEventClient
         slug="test-event"
         initialSnapshot={snapshot}
-        initialSession={null}
+        initialSession={{
+          participantId: "p1",
+          displayName: "Felix",
+        }}
         timezones={defaultTimezones}
       />,
     );
@@ -292,7 +295,7 @@ describe("PublicEventClient", () => {
     await user.click(screen.getByRole("combobox", { name: "Display timezone" }));
     await user.click(screen.getByRole("option", { name: /America\/New_York/ }));
 
-    expect(screen.getAllByText("Mon, Mar 30 · 03:00–04:00")).toHaveLength(2);
+    expect(screen.getAllByText("Mon, Mar 30 · 03:00-04:00")).toHaveLength(2);
   });
 
   it("renders local fixed-date labels after a manual timezone override", async () => {
@@ -303,7 +306,7 @@ describe("PublicEventClient", () => {
         slotStart: "2026-03-30T07:00:00.000Z",
         slotEnd: "2026-03-30T08:00:00.000Z",
         dateKey: "2026-03-30",
-        label: "Mon, Mar 30 · 09:00–10:00",
+        label: "Mon, Mar 30 · 09:00-10:00",
         localLabel: null,
         availableCount: 2,
         participantIds: ["p1", "p2"],
@@ -322,7 +325,7 @@ describe("PublicEventClient", () => {
     await user.click(screen.getByRole("combobox", { name: "Display timezone" }));
     await user.click(screen.getByRole("option", { name: /America\/New_York/ }));
 
-    expect(screen.getAllByText("Mon, Mar 30 · 03:00–04:00")).toHaveLength(2);
+    expect(screen.getAllByText("Mon, Mar 30 · 03:00-04:00")).toHaveLength(2);
   });
 
   it("reads a stored timezone override on remount", async () => {
@@ -546,7 +549,7 @@ describe("PublicEventClient", () => {
   });
 
   it("uses relative overlap buckets for cells and legend based on the current maximum overlap", () => {
-    const snapshot = createSnapshot({ withCurrentUser: false });
+    const snapshot = createSnapshot({ status: "CLOSED", withCurrentUser: false });
     snapshot.slots = snapshot.slots.map((slot) => {
       if (slot.slotStart === "2026-03-30T07:00:00.000Z") {
         return {
@@ -706,20 +709,23 @@ describe("PublicEventClient", () => {
       />,
     );
 
-    expect(await screen.findByText("Mon, Mar 30 – Tue, Mar 31")).toBeInTheDocument();
+    expect(await screen.findByText("More days ahead")).toBeInTheDocument();
+    expect(await screen.findByText("Mon, Mar 30 - Tue, Mar 31")).toBeInTheDocument();
     expect(await screen.findByText("Days 1 - 2 of 5")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Show previous days" })).toBeDisabled();
 
     fireEvent.click(screen.getByRole("button", { name: "Show next days" }));
 
-    expect(await screen.findByText("Tue, Mar 31 – Wed, Apr 1")).toBeInTheDocument();
+    expect(await screen.findByText("Tue, Mar 31 - Wed, Apr 1")).toBeInTheDocument();
     expect(await screen.findByText("Days 2 - 3 of 5")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Show previous days" })).toBeEnabled();
 
     fireEvent.click(screen.getByRole("button", { name: "Show next days" }));
     fireEvent.click(screen.getByRole("button", { name: "Show next days" }));
 
-    expect(await screen.findByText("Thu, Apr 2 – Fri, Apr 3")).toBeInTheDocument();
+    expect(await screen.findByText("Thu, Apr 2 - Fri, Apr 3")).toBeInTheDocument();
+    expect(screen.getByText("Earlier days available")).toBeInTheDocument();
+    expect(screen.queryByText("More days ahead")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Show next days" })).toBeDisabled();
   });
 
@@ -756,7 +762,7 @@ describe("PublicEventClient", () => {
     expect(screen.queryByText("Slot details")).not.toBeInTheDocument();
   });
 
-  it("stays in view mode when there is no editable session", () => {
+  it("shows the join flow and hides the heatmap for open events without a session", () => {
     renderWithI18n(
       <PublicEventClient
         slug="test-event"
@@ -765,9 +771,97 @@ describe("PublicEventClient", () => {
       />,
     );
 
+    expect(screen.getByRole("heading", { name: "Test Event" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Enter your name" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Select availability" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Join event" })).toBeDisabled();
+    expect(document.querySelector('[data-slot="event-heatmap-grid"]')).toBeNull();
+    expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+  });
+
+  it("shows the heatmap after a participant joins", async () => {
+    const user = userEvent.setup();
+    const joinedSnapshot = createSnapshot();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === "/api/events/test-event/participants") {
+        expect(init?.method).toBe("POST");
+        return {
+          ok: true,
+          json: async () => ({
+            session: {
+              participantId: "p1",
+              displayName: "Felix",
+            },
+          }),
+        };
+      }
+
+      if (String(input) === "/api/events/test-event") {
+        return {
+          ok: true,
+          json: async () => ({ snapshot: joinedSnapshot }),
+        };
+      }
+
+      throw new Error(`Unhandled fetch call: ${String(input)}`);
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    renderWithI18n(
+      <PublicEventClient
+        slug="test-event"
+        initialSnapshot={createSnapshot({ withCurrentUser: false })}
+        initialSession={null}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Your name"), "Felix");
+    await user.click(screen.getByRole("button", { name: "Join event" }));
+
+    expect(await screen.findByRole("button", { name: "Edit" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(document.querySelector('[data-slot="event-heatmap-grid"]')).not.toBeNull();
+    expect(screen.queryByRole("heading", { name: "Enter your name" })).not.toBeInTheDocument();
+  });
+
+  it("keeps join errors visible before the heatmap is shown", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      json: async () => ({ error: "This name is already taken." }),
+    }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    renderWithI18n(
+      <PublicEventClient
+        slug="test-event"
+        initialSnapshot={createSnapshot({ withCurrentUser: false })}
+        initialSession={null}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Your name"), "Felix");
+    await user.click(screen.getByRole("button", { name: "Join event" }));
+
+    expect(await screen.findByText("This name is already taken.")).toBeInTheDocument();
+    expect(document.querySelector('[data-slot="event-heatmap-grid"]')).toBeNull();
+  });
+
+  it("shows closed events without requiring a participant session", () => {
+    renderWithI18n(
+      <PublicEventClient
+        slug="test-event"
+        initialSnapshot={createSnapshot({ status: "CLOSED", withCurrentUser: false })}
+        initialSession={null}
+      />,
+    );
+
     expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "View" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByText(/Click any slot to see who is available and who is not\./i)).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Enter your name" })).not.toBeInTheDocument();
   });
 
   it("stays in view mode when the event is closed", () => {
@@ -851,7 +945,10 @@ describe("PublicEventClient", () => {
         slug="test-event"
         shareUrl="https://tempoll.app/e/test-event"
         initialSnapshot={createSnapshot()}
-        initialSession={null}
+        initialSession={{
+          participantId: "p1",
+          displayName: "Felix",
+        }}
       />,
     );
 
@@ -869,7 +966,10 @@ describe("PublicEventClient", () => {
         slug="test-event"
         shareUrl="https://tempoll.app/e/test-event"
         initialSnapshot={createSnapshot({ dayCount: 7 })}
-        initialSession={null}
+        initialSession={{
+          participantId: "p1",
+          displayName: "Felix",
+        }}
       />,
       { locale: "de" },
     );

--- a/src/components/public-event-client.test.tsx
+++ b/src/components/public-event-client.test.tsx
@@ -718,6 +718,8 @@ describe("PublicEventClient", () => {
 
     expect(await screen.findByText("Tue, Mar 31 - Wed, Apr 1")).toBeInTheDocument();
     expect(await screen.findByText("Days 2 - 3 of 5")).toBeInTheDocument();
+    expect(screen.getByText("More days available")).toBeInTheDocument();
+    expect(screen.queryByText("More days ahead")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Show previous days" })).toBeEnabled();
 
     fireEvent.click(screen.getByRole("button", { name: "Show next days" }));
@@ -779,12 +781,41 @@ describe("PublicEventClient", () => {
     expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
   });
 
+  it("keeps the join button disabled until the name matches backend length limits", async () => {
+    const user = userEvent.setup();
+
+    renderWithI18n(
+      <PublicEventClient
+        slug="test-event"
+        initialSnapshot={createSnapshot({ withCurrentUser: false })}
+        initialSession={null}
+      />,
+    );
+
+    const nameInput = screen.getByLabelText("Your name");
+    const joinButton = screen.getByRole("button", { name: "Join event" });
+
+    await user.type(nameInput, "A");
+    expect(joinButton).toBeDisabled();
+
+    await user.clear(nameInput);
+    await user.type(nameInput, "Al");
+    expect(joinButton).toBeEnabled();
+
+    await user.clear(nameInput);
+    await user.type(nameInput, "A".repeat(33));
+    expect(joinButton).toBeDisabled();
+  });
+
   it("shows the heatmap after a participant joins", async () => {
     const user = userEvent.setup();
     const joinedSnapshot = createSnapshot();
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       if (String(input) === "/api/events/test-event/participants") {
         expect(init?.method).toBe("POST");
+        expect(JSON.parse(String(init?.body))).toEqual({
+          displayName: "Felix",
+        });
         return {
           ok: true,
           json: async () => ({
@@ -815,7 +846,7 @@ describe("PublicEventClient", () => {
       />,
     );
 
-    await user.type(screen.getByLabelText("Your name"), "Felix");
+    await user.type(screen.getByLabelText("Your name"), " Felix ");
     await user.click(screen.getByRole("button", { name: "Join event" }));
 
     expect(await screen.findByRole("button", { name: "Edit" })).toHaveAttribute(

--- a/src/components/public-event-client.tsx
+++ b/src/components/public-event-client.tsx
@@ -95,6 +95,8 @@ export function PublicEventClient({
     lastSavedSignatureRef.current = getSelectedSlotStarts(nextSnapshot).join("|");
   }, []);
   const canEdit = Boolean(session && snapshot.status === "OPEN");
+  const shouldShowPreJoin = !session && snapshot.status === "OPEN";
+  const canJoin = snapshot.status === "OPEN" && name.trim().length > 0;
   const hasAnyAvailability = snapshot.participants.some(
     (participant) => participant.selectedSlotCount > 0,
   );
@@ -257,6 +259,10 @@ export function PublicEventClient({
   }, [canEdit]);
 
   async function handleJoin() {
+    if (!canJoin) {
+      return;
+    }
+
     setJoining(true);
     setJoinError(null);
 
@@ -397,26 +403,54 @@ export function PublicEventClient({
 
   return (
     <div className="space-y-4">
-      {!session ? (
-        <Card>
-          <CardHeader className="p-4 pb-2">
-            <CardTitle className="text-base">{messages.publicEvent.joinTitle}</CardTitle>
-            <CardDescription className="text-xs">
+      {shouldShowPreJoin ? (
+        <Card className="overflow-hidden">
+          <CardHeader className="border-b bg-muted/20 p-5">
+            <CardTitle role="heading" aria-level={1} className="text-2xl">
+              {snapshot.title}
+            </CardTitle>
+            <CardDescription className="text-sm">
               {messages.publicEvent.joinDescription}
             </CardDescription>
           </CardHeader>
-          <CardContent className="p-4 pt-0">
-            <div className="flex flex-col gap-3 md:flex-row md:items-end">
-              <div className="flex-1 space-y-2">
-                <Label htmlFor="displayName">{messages.publicEvent.yourNameLabel}</Label>
-                <Input
-                  id="displayName"
-                  value={name}
-                  onChange={(event) => setName(event.target.value)}
-                  placeholder={messages.publicEvent.yourNamePlaceholder}
-                />
+          <CardContent className="space-y-5 p-5">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="rounded-md border bg-background p-4">
+                <div className="mb-3 flex items-center gap-2">
+                  <span className="flex size-7 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
+                    1
+                  </span>
+                  <h2 className="text-sm font-semibold text-foreground">
+                    {messages.publicEvent.joinStepNameTitle}
+                  </h2>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="displayName">{messages.publicEvent.yourNameLabel}</Label>
+                  <Input
+                    id="displayName"
+                    value={name}
+                    onChange={(event) => setName(event.target.value)}
+                    placeholder={messages.publicEvent.yourNamePlaceholder}
+                  />
+                </div>
               </div>
-              <Button onClick={handleJoin} disabled={joining || snapshot.status === "CLOSED"}>
+              <div className="rounded-md border border-dashed bg-muted/20 p-4 text-muted-foreground">
+                <div className="mb-3 flex items-center gap-2">
+                  <span className="flex size-7 items-center justify-center rounded-full border bg-background text-xs font-semibold">
+                    2
+                  </span>
+                  <h2 className="text-sm font-semibold text-foreground">
+                    {messages.publicEvent.joinStepAvailabilityTitle}
+                  </h2>
+                </div>
+                <p className="text-sm">{messages.publicEvent.joinStepAvailabilityDescription}</p>
+              </div>
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-muted-foreground">
+                {messages.publicEvent.joinGateDescription}
+              </p>
+              <Button onClick={handleJoin} disabled={joining || !canJoin} className="sm:min-w-36">
                 {joining ? <Loader2Icon className="size-4 animate-spin" /> : null}
                 {messages.publicEvent.joinButton}
               </Button>
@@ -426,21 +460,23 @@ export function PublicEventClient({
         </Card>
       ) : null}
 
-      <EventHeatmap
-        snapshot={snapshot}
-        mode={mode}
-        onModeChange={setMode}
-        canEdit={canEdit}
-        selectedMap={selectedMap}
-        onUpdateCell={updateCell}
-        finalSlotStart={snapshot.finalizedSlot?.slotStart ?? null}
-        sessionBadgeLabel={session?.displayName ?? null}
-        sidebarTopContent={sidebarTopContent}
-        timezoneOptions={timezoneOptions}
-        viewerTimezone={viewerTimezone}
-        viewerTimezoneSelectValue={viewerTimezoneSelectValue}
-        onViewerTimezoneChange={setViewerTimezonePreference}
-      />
+      {shouldShowPreJoin ? null : (
+        <EventHeatmap
+          snapshot={snapshot}
+          mode={mode}
+          onModeChange={setMode}
+          canEdit={canEdit}
+          selectedMap={selectedMap}
+          onUpdateCell={updateCell}
+          finalSlotStart={snapshot.finalizedSlot?.slotStart ?? null}
+          sessionBadgeLabel={session?.displayName ?? null}
+          sidebarTopContent={sidebarTopContent}
+          timezoneOptions={timezoneOptions}
+          viewerTimezone={viewerTimezone}
+          viewerTimezoneSelectValue={viewerTimezoneSelectValue}
+          onViewerTimezoneChange={setViewerTimezonePreference}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/public-event-client.tsx
+++ b/src/components/public-event-client.tsx
@@ -96,7 +96,9 @@ export function PublicEventClient({
   }, []);
   const canEdit = Boolean(session && snapshot.status === "OPEN");
   const shouldShowPreJoin = !session && snapshot.status === "OPEN";
-  const canJoin = snapshot.status === "OPEN" && name.trim().length > 0;
+  const trimmedName = name.trim();
+  const canJoin =
+    snapshot.status === "OPEN" && trimmedName.length >= 2 && trimmedName.length <= 32;
   const hasAnyAvailability = snapshot.participants.some(
     (participant) => participant.selectedSlotCount > 0,
   );
@@ -272,7 +274,7 @@ export function PublicEventClient({
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        displayName: name,
+        displayName: trimmedName,
       }),
     });
 

--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -344,7 +344,7 @@ export function formatMeetingWindowLabels({
   return {
     label: `${formatInTimeZone(start, timezone, locale === "de" ? "EEE, d. MMM · HH:mm" : "EEE, MMM d · HH:mm", {
       locale: getDateFnsLocale(locale),
-    })}–${formatInTimeZone(end, timezone, "HH:mm", {
+    })}-${formatInTimeZone(end, timezone, "HH:mm", {
       locale: getDateFnsLocale(locale),
     })}`,
     localLabel:
@@ -356,7 +356,7 @@ export function formatMeetingWindowLabels({
             {
               locale: getDateFnsLocale(locale),
             },
-          )}–${formatInTimeZone(end, viewerTimezone, "HH:mm", {
+          )}-${formatInTimeZone(end, viewerTimezone, "HH:mm", {
             locale: getDateFnsLocale(locale),
           })}`
         : null,

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -200,6 +200,12 @@ export const en = {
     participantHighlighting: "Highlighting",
     joinTitle: "Join this board",
     joinDescription: "Enter your name to start selecting the times that work for you.",
+    joinStepNameTitle: "Enter your name",
+    joinStepAvailabilityTitle: "Select availability",
+    joinStepAvailabilityDescription:
+      "The availability grid appears after you join, so your choices are saved to your name.",
+    joinGateDescription:
+      "First enter your name. Then you can mark the times that work for you.",
     yourNameLabel: "Your name",
     yourNamePlaceholder: "Alex, Nora, Product team...",
     joinButton: "Join event",
@@ -222,6 +228,9 @@ export const en = {
     showPreviousDays: "Show previous days",
     showNextDays: "Show next days",
     dayWindowSummary: "Days {start} - {end} of {total}",
+    moreDaysAvailable: "More days available",
+    moreDaysAhead: "More days ahead",
+    earlierDaysAvailable: "Earlier days available",
     availableCountTitle:
       "{date} {time} · {available}/{total} available · {names}",
     nobodyAvailableTitle: "{date} {time} · nobody available",
@@ -849,6 +858,12 @@ export const de: Messages = {
     joinTitle: "Diesem Board beitreten",
     joinDescription:
       "Gib deinen Namen ein, um die Zeiten zu markieren, die für dich passen.",
+    joinStepNameTitle: "Namen eingeben",
+    joinStepAvailabilityTitle: "Verfügbarkeit auswählen",
+    joinStepAvailabilityDescription:
+      "Das Verfügbarkeitsraster erscheint nach dem Beitritt, damit deine Auswahl mit deinem Namen gespeichert wird.",
+    joinGateDescription:
+      "Gib zuerst deinen Namen ein. Danach kannst du die passenden Zeiten markieren.",
     yourNameLabel: "Dein Name",
     yourNamePlaceholder: "Alex, Nora, Produktteam...",
     joinButton: "Event beitreten",
@@ -872,6 +887,9 @@ export const de: Messages = {
     showPreviousDays: "Vorherige Tage anzeigen",
     showNextDays: "Nächste Tage anzeigen",
     dayWindowSummary: "Tage {start} - {end} von {total}",
+    moreDaysAvailable: "Weitere Tage verfügbar",
+    moreDaysAhead: "Weitere Tage folgen",
+    earlierDaysAvailable: "Frühere Tage verfügbar",
     availableCountTitle:
       "{date} {time} · {available}/{total} verfügbar · {names}",
     nobodyAvailableTitle: "{date} {time} · niemand verfügbar",


### PR DESCRIPTION
## Summary
- Hide the availability grid for open events until a participant enters a name and joins successfully
- Make the day window controls more prominent on the public heatmap, with clearer messaging when more days are available
- Update shared time-range labels and align tests with the new public entry flow

## Testing
- `pnpm test:run src/components/public-event-client.test.tsx`
- `pnpm test:run src/components/manage-event-client.test.tsx`
- `pnpm verify`