### PR TITLE
Add weekday filtering to event creation

### DIFF
--- a/src/components/create-event-form.test.tsx
+++ b/src/components/create-event-form.test.tsx
@@ -58,6 +58,9 @@ describe("CreateEventForm", () => {
     renderCreateEventForm("de");
 
     expect(screen.getByLabelText("Event-Titel")).toBeInTheDocument();
+    expect(screen.getByText("Verfügbare Wochentage")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Montag" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Samstag" })).not.toBeChecked();
     expect(screen.getByRole("button", { name: "Event erstellen" })).toBeInTheDocument();
   });
 
@@ -65,6 +68,18 @@ describe("CreateEventForm", () => {
     renderCreateEventForm();
 
     expect(screen.getByRole("combobox", { name: "Slot size" })).toHaveTextContent("60 min");
+  });
+
+  it("defaults weekdays to Monday through Friday", () => {
+    renderCreateEventForm();
+
+    expect(screen.getByRole("checkbox", { name: "Monday" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Tuesday" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Wednesday" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Thursday" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Friday" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Saturday" })).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Sunday" })).not.toBeChecked();
   });
 
   it("shows a friendly inline title validation message before submitting", () => {
@@ -189,6 +204,60 @@ describe("CreateEventForm", () => {
       dayEndMinutes: 17 * 60,
       slotMinutes: 15,
     });
+  });
+
+  it("submits only enabled weekdays from the selected date range", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-02T10:00:00.000Z"));
+
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        manageKey: "manage-key-123",
+      }),
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    renderCreateEventForm();
+    vi.useRealTimers();
+
+    await user.type(screen.getByLabelText("Event title"), "Sprint planning");
+    await user.click(screen.getByRole("checkbox", { name: "Friday" }));
+    await user.click(screen.getByRole("checkbox", { name: "Sunday" }));
+    await user.click(screen.getByRole("button", { name: "Create event" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const payload = JSON.parse(String(requestInit.body)) as {
+      dates: string[];
+    };
+
+    expect(payload.dates).toEqual(["2026-04-05"]);
+  });
+
+  it("requires at least one enabled weekday inside the selected date range", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-02T10:00:00.000Z"));
+
+    const user = userEvent.setup();
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as typeof fetch;
+
+    renderCreateEventForm();
+    vi.useRealTimers();
+
+    await user.type(screen.getByLabelText("Event title"), "Sprint planning");
+    await user.click(screen.getByRole("checkbox", { name: "Friday" }));
+    await user.click(screen.getByRole("button", { name: "Create event" }));
+
+    expect(
+      screen.getByText("Select at least one available weekday inside the date range."),
+    ).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("submits the optional notification email when alerts are available", async () => {

--- a/src/components/create-event-form.test.tsx
+++ b/src/components/create-event-form.test.tsx
@@ -58,7 +58,7 @@ describe("CreateEventForm", () => {
     renderCreateEventForm("de");
 
     expect(screen.getByLabelText("Event-Titel")).toBeInTheDocument();
-    expect(screen.getByText("Verfügbare Wochentage")).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Verfügbare Wochentage" })).toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Montag" })).toBeChecked();
     expect(screen.getByRole("checkbox", { name: "Samstag" })).not.toBeChecked();
     expect(screen.getByRole("button", { name: "Event erstellen" })).toBeInTheDocument();
@@ -210,7 +210,6 @@ describe("CreateEventForm", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-02T10:00:00.000Z"));
 
-    const user = userEvent.setup();
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -221,6 +220,7 @@ describe("CreateEventForm", () => {
 
     renderCreateEventForm();
     vi.useRealTimers();
+    const user = userEvent.setup();
 
     await user.type(screen.getByLabelText("Event title"), "Sprint planning");
     await user.click(screen.getByRole("checkbox", { name: "Friday" }));
@@ -243,12 +243,12 @@ describe("CreateEventForm", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-02T10:00:00.000Z"));
 
-    const user = userEvent.setup();
     const fetchMock = vi.fn();
     global.fetch = fetchMock as typeof fetch;
 
     renderCreateEventForm();
     vi.useRealTimers();
+    const user = userEvent.setup();
 
     await user.type(screen.getByLabelText("Event title"), "Sprint planning");
     await user.click(screen.getByRole("checkbox", { name: "Friday" }));
@@ -257,6 +257,14 @@ describe("CreateEventForm", () => {
     expect(
       screen.getByText("Select at least one available weekday inside the date range."),
     ).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Available weekdays" })).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+    expect(screen.getByRole("group", { name: "Available weekdays" })).toHaveAttribute(
+      "aria-describedby",
+      "weekday-filter-description weekday-filter-error",
+    );
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/src/components/create-event-form.tsx
+++ b/src/components/create-event-form.tsx
@@ -593,18 +593,25 @@ export function CreateEventForm({
                 ) : null}
               </div>
 
-              <div
+              <fieldset
                 id={eventFieldIds.weekdays}
                 tabIndex={-1}
+                aria-describedby={
+                  fieldErrors.weekdays
+                    ? "weekday-filter-description weekday-filter-error"
+                    : "weekday-filter-description"
+                }
+                aria-invalid={fieldErrors.weekdays ? true : undefined}
                 className="space-y-2 rounded-md focus:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 md:col-span-2"
               >
+                <legend className="sr-only">{messages.createEvent.weekdays.label}</legend>
                 <div className="flex flex-wrap items-center justify-between gap-2">
-                  <Label>{messages.createEvent.weekdays.label}</Label>
+                  <span className="text-sm font-medium">{messages.createEvent.weekdays.label}</span>
                   <Badge variant="secondary" className="rounded-full px-2.5">
                     {plural(messages.createEvent.range.days, selectedFilteredRangeDays)}
                   </Badge>
                 </div>
-                <p className="text-sm text-muted-foreground">
+                <p id="weekday-filter-description" className="text-sm text-muted-foreground">
                   {messages.createEvent.weekdays.description}
                 </p>
                 <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 lg:grid-cols-7">
@@ -640,11 +647,11 @@ export function CreateEventForm({
                   })}
                 </div>
                 {fieldErrors.weekdays ? (
-                  <p className="text-sm text-destructive">
+                  <p id="weekday-filter-error" className="text-sm text-destructive">
                     {fieldErrors.weekdays}
                   </p>
                 ) : null}
-              </div>
+              </fieldset>
             </div>
 
             <Separator />

--- a/src/components/create-event-form.tsx
+++ b/src/components/create-event-form.tsx
@@ -5,6 +5,7 @@ import type { DateRange } from "react-day-picker";
 import {
   CalendarRangeIcon,
   ChevronDownIcon,
+  CheckIcon,
   Loader2Icon,
   SparklesIcon,
 } from "lucide-react";
@@ -50,6 +51,7 @@ const eventFieldOrder = [
   "notificationEmail",
   "timezone",
   "dates",
+  "weekdays",
   "dayStartMinutes",
   "dayEndMinutes",
   "slotMinutes",
@@ -64,6 +66,7 @@ const eventFieldIds: Record<EventField, string> = {
   notificationEmail: "notification-email",
   timezone: "timezone-trigger",
   dates: "date-range-trigger",
+  weekdays: "weekday-filter",
   dayStartMinutes: "day-start-trigger",
   dayEndMinutes: "day-end-trigger",
   slotMinutes: "slot-size-trigger",
@@ -71,6 +74,28 @@ const eventFieldIds: Record<EventField, string> = {
 };
 
 const eventFieldSet = new Set<EventField>(eventFieldOrder);
+
+const weekdayOptions = [
+  { value: 1, messageKey: "monday", defaultSelected: true },
+  { value: 2, messageKey: "tuesday", defaultSelected: true },
+  { value: 3, messageKey: "wednesday", defaultSelected: true },
+  { value: 4, messageKey: "thursday", defaultSelected: true },
+  { value: 5, messageKey: "friday", defaultSelected: true },
+  { value: 6, messageKey: "saturday", defaultSelected: false },
+  { value: 0, messageKey: "sunday", defaultSelected: false },
+] as const;
+
+const defaultSelectedWeekdays = weekdayOptions
+  .filter((weekday) => weekday.defaultSelected)
+  .map((weekday) => weekday.value);
+
+function sortWeekdays(values: number[]) {
+  return [...values].sort(
+    (left, right) =>
+      weekdayOptions.findIndex((weekday) => weekday.value === left) -
+      weekdayOptions.findIndex((weekday) => weekday.value === right),
+  );
+}
 
 function getRangeLabel(
   range: DateRange | undefined,
@@ -101,6 +126,34 @@ function getRangeDays(range: DateRange | undefined) {
     start: range.from,
     end: range.to,
   }).length;
+}
+
+function getFilteredRangeDays(range: DateRange | undefined, selectedWeekdays: number[]) {
+  if (!range?.from || !range?.to) {
+    return 0;
+  }
+
+  const selectedWeekdaySet = new Set(selectedWeekdays);
+
+  return eachDayOfInterval({
+    start: range.from,
+    end: range.to,
+  }).filter((date) => selectedWeekdaySet.has(date.getDay())).length;
+}
+
+function expandRangeToDateKeys(range: DateRange, selectedWeekdays: number[]) {
+  if (!range.from || !range.to) {
+    return [];
+  }
+
+  const selectedWeekdaySet = new Set(selectedWeekdays);
+
+  return eachDayOfInterval({
+    start: range.from,
+    end: range.to,
+  })
+    .filter((date) => selectedWeekdaySet.has(date.getDay()))
+    .map((date) => format(date, "yyyy-MM-dd"));
 }
 
 export function CreateEventForm({
@@ -148,14 +201,9 @@ export function CreateEventForm({
   const [dayEndMinutes, setDayEndMinutes] = useState(
     defaultCreateEventDefaults.dayEndMinutes,
   );
-
-  const selectedDates =
-    dateRange?.from && dateRange?.to
-      ? eachDayOfInterval({
-          start: dateRange.from,
-          end: dateRange.to,
-        }).map((date) => format(date, "yyyy-MM-dd"))
-      : [];
+  const [selectedWeekdays, setSelectedWeekdays] = useState<number[]>(
+    defaultSelectedWeekdays,
+  );
 
   const compactDateLabel = locale === "de" ? "d. MMM yyyy" : "MMM d, yyyy";
   const selectedRangeLabel = getRangeLabel(dateRange, compactDateLabel, messages, dateFnsLocale);
@@ -167,6 +215,7 @@ export function CreateEventForm({
   );
   const selectedRangeDays = getRangeDays(dateRange);
   const draftRangeDays = getRangeDays(draftDateRange);
+  const selectedFilteredRangeDays = getFilteredRangeDays(dateRange, selectedWeekdays);
   const timezoneOptions = useMemo(
     () =>
       buildTimezoneOptions(
@@ -255,6 +304,17 @@ export function CreateEventForm({
     setIsRangePickerOpen(false);
   }
 
+  function toggleWeekday(value: number) {
+    setSelectedWeekdays((current) => {
+      if (current.includes(value)) {
+        return current.filter((weekday) => weekday !== value);
+      }
+
+      return sortWeekdays([...current, value]);
+    });
+    clearErrors("weekdays", "dates");
+  }
+
   function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setErrorMessage(null);
@@ -264,6 +324,16 @@ export function CreateEventForm({
         dates: messages.validation.eventCreate.dateRangeRequired,
       });
       focusField("dates");
+      return;
+    }
+
+    const selectedDates = expandRangeToDateKeys(dateRange, selectedWeekdays);
+
+    if (selectedDates.length === 0) {
+      setFieldErrors({
+        weekdays: messages.validation.eventCreate.weekdayRequired,
+      });
+      focusField("weekdays");
       return;
     }
 
@@ -522,6 +592,59 @@ export function CreateEventForm({
                   </p>
                 ) : null}
               </div>
+
+              <div
+                id={eventFieldIds.weekdays}
+                tabIndex={-1}
+                className="space-y-2 rounded-md focus:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 md:col-span-2"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <Label>{messages.createEvent.weekdays.label}</Label>
+                  <Badge variant="secondary" className="rounded-full px-2.5">
+                    {plural(messages.createEvent.range.days, selectedFilteredRangeDays)}
+                  </Badge>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  {messages.createEvent.weekdays.description}
+                </p>
+                <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 lg:grid-cols-7">
+                  {weekdayOptions.map((weekday) => {
+                    const isSelected = selectedWeekdays.includes(weekday.value);
+                    const weekdayMessage =
+                      messages.createEvent.weekdays.options[weekday.messageKey];
+
+                    return (
+                      <label
+                        key={weekday.value}
+                        className={cn(
+                          "flex min-h-12 cursor-pointer items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm transition-colors",
+                          isSelected
+                            ? "border-primary bg-primary/10 text-foreground"
+                            : "border-border bg-background text-muted-foreground hover:bg-muted/50",
+                        )}
+                      >
+                        <input
+                          type="checkbox"
+                          className="sr-only"
+                          aria-label={weekdayMessage.label}
+                          checked={isSelected}
+                          onChange={() => toggleWeekday(weekday.value)}
+                        />
+                        <span className="min-w-0" aria-hidden="true">
+                          <span className="block font-medium">{weekdayMessage.shortLabel}</span>
+                          <span className="block truncate text-xs">{weekdayMessage.label}</span>
+                        </span>
+                        {isSelected ? <CheckIcon className="size-4 shrink-0" aria-hidden="true" /> : null}
+                      </label>
+                    );
+                  })}
+                </div>
+                {fieldErrors.weekdays ? (
+                  <p className="text-sm text-destructive">
+                    {fieldErrors.weekdays}
+                  </p>
+                ) : null}
+              </div>
             </div>
 
             <Separator />
@@ -709,7 +832,7 @@ export function CreateEventForm({
               </div>
               <div className="flex items-center justify-between gap-4">
                 <dt className="text-muted-foreground">{messages.createEvent.previewFields.daysShown}</dt>
-                <dd className="font-medium">{selectedRangeDays}</dd>
+                <dd className="font-medium">{selectedFilteredRangeDays}</dd>
               </div>
               <div className="flex items-center justify-between gap-4">
                 <dt className="text-muted-foreground">{messages.createEvent.previewFields.dailyWindow}</dt>

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -114,7 +114,7 @@ export const en = {
   createEvent: {
     eventDetailsTitle: "Event details",
     eventDetailsDescription:
-      "Set one date range, choose the daily window, and share a single link. Every day inside the selected range will appear on the availability grid.",
+      "Set one date range, choose available weekdays and the daily window, then share a single link.",
     titleLabel: "Event title",
     titlePlaceholder: "Design review, sprint planning, dinner with friends...",
     timezoneLabel: "Timezone",
@@ -122,7 +122,21 @@ export const en = {
     dateRangeLabel: "Date range",
     dateRangePlaceholder: "Choose a start and end date",
     dateRangeOpenTitle: "Choose event range",
-    dateRangeOpenDescription: "Weeks start on Monday. The whole interval will be shown.",
+    dateRangeOpenDescription: "Weeks start on Monday. Selected weekdays will appear on the grid.",
+    weekdays: {
+      label: "Available weekdays",
+      description:
+        "Choose which weekdays inside the selected date range should appear on the availability grid.",
+      options: {
+        monday: { shortLabel: "Mon", label: "Monday" },
+        tuesday: { shortLabel: "Tue", label: "Tuesday" },
+        wednesday: { shortLabel: "Wed", label: "Wednesday" },
+        thursday: { shortLabel: "Thu", label: "Thursday" },
+        friday: { shortLabel: "Fri", label: "Friday" },
+        saturday: { shortLabel: "Sat", label: "Saturday" },
+        sunday: { shortLabel: "Sun", label: "Sunday" },
+      },
+    },
     dailyStartLabel: "Daily start",
     dailyStartPlaceholder: "Pick a start time",
     dailyEndLabel: "Daily end",
@@ -156,7 +170,7 @@ export const en = {
       publicPage: "A public event page people can join without creating an account.",
       privatePage: "A private organizer page for renaming participants and closing the poll.",
       liveGrid:
-        "A live availability grid that fills every day between the chosen start and end date.",
+        "A live availability grid for the selected weekdays between the chosen start and end date.",
     },
     range: {
       selected: "{count} selected",
@@ -619,6 +633,7 @@ export const en = {
       endAfterStart: "End time must be later than start time.",
       durationMatchesSlot: "Meeting duration must align with slot size.",
       dateRangeRequired: "Choose a start and end date for the event.",
+      weekdayRequired: "Select at least one available weekday inside the date range.",
     },
     participantCreate: {
       nameMin: "Enter a name with at least 2 characters.",
@@ -759,7 +774,7 @@ export const de: Messages = {
   createEvent: {
     eventDetailsTitle: "Event-Details",
     eventDetailsDescription:
-      "Lege einen Datumsbereich fest, wähle das tägliche Zeitfenster und teile anschließend einen einzigen Link. Jeder Tag im ausgewählten Bereich erscheint im Verfügbarkeitsraster.",
+      "Lege einen Datumsbereich fest, wähle verfügbare Wochentage und das tägliche Zeitfenster und teile anschließend einen einzigen Link.",
     titleLabel: "Event-Titel",
     titlePlaceholder: "Design-Review, Sprint-Planung, Abendessen mit Freund:innen...",
     timezoneLabel: "Zeitzone",
@@ -767,7 +782,22 @@ export const de: Messages = {
     dateRangeLabel: "Datumsbereich",
     dateRangePlaceholder: "Start- und Enddatum wählen",
     dateRangeOpenTitle: "Event-Bereich wählen",
-    dateRangeOpenDescription: "Wochen beginnen am Montag. Das gesamte Intervall wird angezeigt.",
+    dateRangeOpenDescription:
+      "Wochen beginnen am Montag. Ausgewählte Wochentage erscheinen im Raster.",
+    weekdays: {
+      label: "Verfügbare Wochentage",
+      description:
+        "Wähle, welche Wochentage im ausgewählten Datumsbereich im Verfügbarkeitsraster erscheinen sollen.",
+      options: {
+        monday: { shortLabel: "Mo", label: "Montag" },
+        tuesday: { shortLabel: "Di", label: "Dienstag" },
+        wednesday: { shortLabel: "Mi", label: "Mittwoch" },
+        thursday: { shortLabel: "Do", label: "Donnerstag" },
+        friday: { shortLabel: "Fr", label: "Freitag" },
+        saturday: { shortLabel: "Sa", label: "Samstag" },
+        sunday: { shortLabel: "So", label: "Sonntag" },
+      },
+    },
     dailyStartLabel: "Tagesbeginn",
     dailyStartPlaceholder: "Startzeit wählen",
     dailyEndLabel: "Tagesende",
@@ -804,7 +834,7 @@ export const de: Messages = {
       privatePage:
         "Eine private Verwaltungsseite zum Umbenennen von Teilnehmenden und Schließen der Umfrage.",
       liveGrid:
-        "Ein Live-Verfügbarkeitsraster für jeden Tag zwischen dem gewählten Start- und Enddatum.",
+        "Ein Live-Verfügbarkeitsraster für die ausgewählten Wochentage zwischen Start- und Enddatum.",
     },
     range: {
       selected: "{count} ausgewählt",
@@ -1293,6 +1323,8 @@ export const de: Messages = {
       endAfterStart: "Die Endzeit muss nach der Startzeit liegen.",
       durationMatchesSlot: "Die Meeting-Dauer muss zur Slot-Größe passen.",
       dateRangeRequired: "Bitte wähle Start- und Enddatum für das Event.",
+      weekdayRequired:
+        "Wähle mindestens einen verfügbaren Wochentag innerhalb des Datumsbereichs.",
     },
     participantCreate: {
       nameMin: "Bitte gib einen Namen mit mindestens 2 Zeichen ein.",


### PR DESCRIPTION
## Summary
- Add a weekday filter to the create flow with Monday-Friday selected by default and Saturday-Sunday off
- Keep the existing date range model and expand it to `dates: string[]` only at submit time, filtering out disabled weekdays
- Update localized copy and preview messaging so the filtered weekday selection is reflected in the UI
- Add tests for default selection, filtered submission payloads, and validation when no weekday remains in range

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:run src/components/create-event-form.test.tsx src/components/public-event-client.test.tsx src/components/manage-event-client.test.tsx`
- `pnpm verify`