### PR TITLE
Fix localized email placeholder

### DIFF
--- a/src/components/create-event-form.test.tsx
+++ b/src/components/create-event-form.test.tsx
@@ -58,6 +58,10 @@ describe("CreateEventForm", () => {
     renderCreateEventForm("de");
 
     expect(screen.getByLabelText("Event-Titel")).toBeInTheDocument();
+    expect(screen.getByLabelText("Organizer-E-Mail-Benachrichtigungen")).toHaveAttribute(
+      "placeholder",
+      "name@beispiel.de",
+    );
     expect(screen.getByRole("group", { name: "Verfügbare Wochentage" })).toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Montag" })).toBeChecked();
     expect(screen.getByRole("checkbox", { name: "Samstag" })).not.toBeChecked();

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -877,7 +877,7 @@ export const de: Messages = {
     meetingDurationLabel: "Meeting-Dauer",
     meetingDurationPlaceholder: "Dauer wählen",
     notificationEmailLabel: "Organizer-E-Mail-Benachrichtigungen",
-    notificationEmailPlaceholder: "[PRIVATE_EMAIL]",
+    notificationEmailPlaceholder: "name@beispiel.de",
     notificationEmailDescription:
       "Optional. Erhalte eine E-Mail, nachdem Teilnehmende ihre Verfügbarkeit 5 ruhige Minuten lang nicht mehr geändert haben.",
     notificationEmailUnavailable:


### PR DESCRIPTION
## Summary
- Replace the German organizer email placeholder token with a localized example address
- Add a regression test to verify the German create-event form renders the localized placeholder

## Testing
- Unit test added for the German create-event form placeholder
- Not run (not requested)