### PR TITLE
Add searchable timezone combobox

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "dotenv": "^17.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1933,6 +1936,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -6153,6 +6162,18 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   code-block-writer@13.0.3: {}
 

--- a/src/components/create-event-form.test.tsx
+++ b/src/components/create-event-form.test.tsx
@@ -172,6 +172,30 @@ describe("CreateEventForm", () => {
     ]);
   });
 
+  it("filters timezone options by search text and keeps the selected value", async () => {
+    const user = userEvent.setup();
+
+    renderWithI18n(
+      <CreateEventForm
+        timezones={["Europe/Vienna", "Europe/Berlin", "America/New_York"]}
+        timeOptions={defaultTimeOptions}
+        notificationsConfigured={true}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Timezone" }));
+    await user.type(screen.getByPlaceholderText("Search timezones..."), "berlin");
+
+    expect(screen.getByRole("option", { name: /Europe\/Berlin/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Europe\/Vienna/ })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("option", { name: /Europe\/Berlin/ }));
+
+    expect(screen.getByRole("combobox", { name: "Timezone" })).toHaveTextContent(
+      "Europe/Berlin",
+    );
+  });
+
   it("submits selected daily window and slot size after a successful event creation", async () => {
     const user = userEvent.setup();
     const fetchMock = vi.fn().mockResolvedValue({

--- a/src/components/create-event-form.tsx
+++ b/src/components/create-event-form.tsx
@@ -18,6 +18,7 @@ import { useRouter } from "next/navigation";
 import { useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
 
+import { TimezoneCombobox } from "@/components/timezone-combobox";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
@@ -686,32 +687,19 @@ export function CreateEventForm({
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div className="space-y-2">
                 <Label htmlFor={eventFieldIds.timezone}>{messages.createEvent.timezoneLabel}</Label>
-                <Select
+                <TimezoneCombobox
+                  id={eventFieldIds.timezone}
+                  label={messages.createEvent.timezoneLabel}
                   value={timezone}
                   onValueChange={(value) => {
                     setTimezone(value);
                     clearErrors("timezone");
                   }}
-                >
-                  <SelectTrigger
-                    id={eventFieldIds.timezone}
-                    aria-invalid={fieldErrors.timezone ? true : undefined}
-                    aria-describedby={fieldErrors.timezone ? "timezone-error" : undefined}
-                    className={cn(
-                      fieldErrors.timezone &&
-                        "border-destructive focus:ring-destructive/20",
-                    )}
-                  >
-                    <SelectValue placeholder={messages.createEvent.timezonePlaceholder} />
-                  </SelectTrigger>
-                  <SelectContent className="max-h-80">
-                    {timezoneOptions.map((timezoneOption) => (
-                      <SelectItem key={timezoneOption.value} value={timezoneOption.value}>
-                        {timezoneOption.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  options={timezoneOptions}
+                  placeholder={messages.createEvent.timezonePlaceholder}
+                  invalid={Boolean(fieldErrors.timezone)}
+                  describedBy={fieldErrors.timezone ? "timezone-error" : undefined}
+                />
                 {fieldErrors.timezone ? (
                   <p id="timezone-error" className="text-sm text-destructive">
                     {fieldErrors.timezone}

--- a/src/components/event-heatmap.tsx
+++ b/src/components/event-heatmap.tsx
@@ -22,6 +22,7 @@ import {
 } from "react";
 
 import { EventMetaDetails } from "@/components/event-meta-details";
+import { TimezoneCombobox } from "@/components/timezone-combobox";
 import {
   buildFinalizedSlot,
   buildProjectedBoard,
@@ -32,19 +33,11 @@ import { useI18n } from "@/lib/i18n/context";
 import { findTimezoneOption } from "@/lib/timezone-options";
 import type { PublicEventSnapshot, SnapshotParticipant, TimezoneOption } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { AUTOMATIC_TIMEZONE_VALUE } from "@/lib/viewer-timezone";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { SegmentedControl, SegmentedControlItem } from "@/components/ui/segmented-control";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 
 export type DraftSelection = Record<string, boolean>;
@@ -1007,25 +1000,16 @@ export function EventHeatmap({
                     >
                       {messages.publicEvent.viewerTimezoneLabel}
                     </Label>
-                    <Select value={viewerTimezoneSelectValue} onValueChange={onViewerTimezoneChange}>
-                      <SelectTrigger
-                        id={viewerTimezoneSelectId}
-                        size="sm"
-                        className="min-w-[11.5rem] bg-background text-xs"
-                      >
-                        <SelectValue placeholder={messages.publicEvent.viewerTimezoneLabel} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value={AUTOMATIC_TIMEZONE_VALUE}>
-                          {messages.publicEvent.viewerTimezoneAutomatic}
-                        </SelectItem>
-                        {timezoneOptions.map((timezoneOption) => (
-                          <SelectItem key={timezoneOption.value} value={timezoneOption.value}>
-                            {timezoneOption.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <TimezoneCombobox
+                      id={viewerTimezoneSelectId}
+                      label={messages.publicEvent.viewerTimezoneLabel}
+                      value={viewerTimezoneSelectValue}
+                      options={timezoneOptions}
+                      onValueChange={onViewerTimezoneChange}
+                      placeholder={messages.publicEvent.viewerTimezoneLabel}
+                      size="sm"
+                      includeAutomatic
+                    />
                   </div>
                   {showModeToggle ? (
                     <SegmentedControl>

--- a/src/components/manage-event-client.test.tsx
+++ b/src/components/manage-event-client.test.tsx
@@ -366,6 +366,11 @@ describe("ManageEventClient", () => {
     renderWithI18n(<ManageEventClient initialView={view} timezones={defaultTimezones} />);
 
     await user.click(screen.getByRole("combobox", { name: "Display timezone" }));
+    await user.type(screen.getByPlaceholderText("Search timezones..."), "new");
+
+    expect(screen.getByRole("option", { name: /America\/New_York/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Europe\/Vienna/ })).not.toBeInTheDocument();
+
     await user.click(screen.getByRole("option", { name: /America\/New_York/ }));
 
     expect(screen.getByRole("combobox", { name: "Display timezone" })).toHaveTextContent(

--- a/src/components/public-event-client.test.tsx
+++ b/src/components/public-event-client.test.tsx
@@ -343,6 +343,11 @@ describe("PublicEventClient", () => {
     expect(timezoneSelect).toHaveTextContent("Automatic");
 
     await user.click(timezoneSelect);
+    await user.type(screen.getByPlaceholderText("Search timezones..."), "new");
+
+    expect(screen.getByRole("option", { name: /America\/New_York/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Automatic" })).not.toBeInTheDocument();
+
     await user.click(screen.getByRole("option", { name: /America\/New_York/ }));
 
     expect(screen.getByRole("combobox", { name: "Display timezone" })).toHaveTextContent(

--- a/src/components/timezone-combobox.tsx
+++ b/src/components/timezone-combobox.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { CheckIcon, ChevronsUpDownIcon } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useI18n } from "@/lib/i18n/context";
+import { formatGmtOffset } from "@/lib/timezone-options";
+import type { TimezoneOption } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { AUTOMATIC_TIMEZONE_VALUE } from "@/lib/viewer-timezone";
+
+type TimezoneComboboxProps = {
+  id: string;
+  label: string;
+  value: string;
+  options: TimezoneOption[];
+  onValueChange: (timezone: string) => void;
+  placeholder: string;
+  invalid?: boolean;
+  describedBy?: string;
+  size?: "sm" | "default";
+  includeAutomatic?: boolean;
+};
+
+type TimezoneComboboxItem = {
+  value: string;
+  label: string;
+  keywords: string[];
+};
+
+function timezoneFilter(value: string, search: string, keywords?: string[]) {
+  const normalizedSearch = search.trim().toLowerCase();
+
+  if (!normalizedSearch) {
+    return 1;
+  }
+
+  const haystack = [value, ...(keywords ?? [])].join(" ").toLowerCase();
+  return haystack.includes(normalizedSearch) ? 1 : 0;
+}
+
+export function TimezoneCombobox({
+  id,
+  label,
+  value,
+  options,
+  onValueChange,
+  placeholder,
+  invalid,
+  describedBy,
+  size = "default",
+  includeAutomatic = false,
+}: TimezoneComboboxProps) {
+  const { messages } = useI18n();
+  const [open, setOpen] = useState(false);
+
+  const items = useMemo<TimezoneComboboxItem[]>(() => {
+    const timezoneItems = options.map((option) => ({
+      value: option.value,
+      label: option.label,
+      keywords: [option.value, option.label, formatGmtOffset(option.offsetMinutes)],
+    }));
+
+    if (!includeAutomatic) {
+      return timezoneItems;
+    }
+
+    return [
+      {
+        value: AUTOMATIC_TIMEZONE_VALUE,
+        label: messages.publicEvent.viewerTimezoneAutomatic,
+        keywords: [messages.publicEvent.viewerTimezoneAutomatic],
+      },
+      ...timezoneItems,
+    ];
+  }, [includeAutomatic, messages.publicEvent.viewerTimezoneAutomatic, options]);
+
+  const selectedItem = items.find((item) => item.value === value) ?? null;
+  const selectedLabel = selectedItem?.label ?? value;
+
+  function selectValue(nextValue: string) {
+    onValueChange(nextValue);
+    setOpen(false);
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-label={label}
+          aria-expanded={open}
+          aria-invalid={invalid ? true : undefined}
+          aria-describedby={describedBy}
+          size={size}
+          className={cn(
+            "w-full justify-between bg-background font-normal",
+            size === "sm" && "min-w-[11.5rem] text-xs",
+            invalid && "border-destructive focus:ring-destructive/20",
+          )}
+        >
+          <span className={cn("truncate", !value && "text-muted-foreground")}>
+            {selectedLabel || placeholder}
+          </span>
+          <ChevronsUpDownIcon className="size-4 opacity-50" aria-hidden="true" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[min(32rem,calc(100vw-2rem))] p-0">
+        <Command filter={timezoneFilter} label={messages.common.timezoneSearchPlaceholder} loop>
+          <CommandInput placeholder={messages.common.timezoneSearchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>{messages.common.timezoneSearchEmpty}</CommandEmpty>
+            <CommandGroup>
+              {items.map((item) => (
+                <CommandItem
+                  key={item.value}
+                  value={item.value}
+                  keywords={item.keywords}
+                  onSelect={selectValue}
+                >
+                  <CheckIcon
+                    className={cn(
+                      "size-4",
+                      item.value === value ? "opacity-100" : "opacity-0",
+                    )}
+                    aria-hidden="true"
+                  />
+                  <span className="truncate">{item.label}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -29,9 +29,13 @@ function CommandInput({
   return (
     <div
       data-slot="command-input-wrapper"
-      className="flex h-9 items-center gap-2 border-b px-3"
+      className="flex items-center gap-2 border-b px-3"
     >
-      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <SearchIcon
+        className="size-4 shrink-0 opacity-50"
+        aria-hidden="true"
+        focusable="false"
+      />
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { SearchIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn("max-h-[18rem] scroll-py-1 overflow-x-hidden overflow-y-auto", className)}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+};

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -50,6 +50,8 @@ export const en = {
     and: "and",
     yes: "Yes",
     no: "No",
+    timezoneSearchPlaceholder: "Search timezones...",
+    timezoneSearchEmpty: "No timezones found.",
   },
   appChrome: {
     newEvent: "New event",
@@ -791,6 +793,8 @@ export const de: Messages = {
     and: "und",
     yes: "Ja",
     no: "Nein",
+    timezoneSearchPlaceholder: "Zeitzonen suchen...",
+    timezoneSearchEmpty: "Keine Zeitzonen gefunden.",
   },
   appChrome: {
     newEvent: "Neues Event",


### PR DESCRIPTION
## Summary
- Replaced the timezone selects with a shared searchable combobox based on `cmdk` and `Popover`.
- Applied the new control to the create flow, public event view, and organizer manage view.
- Added search placeholder and empty-state copy to i18n and kept timezone sorting unchanged.

## Testing
- Added unit tests covering timezone search filtering and selection in the create, public, and manage flows.
- `pnpm verify` passed, including the full test suite, Prisma generation, and production build.